### PR TITLE
Update cmake variables

### DIFF
--- a/src/common/gsa/build.rst
+++ b/src/common/gsa/build.rst
@@ -9,6 +9,8 @@
     -DSYSCONFDIR=/etc \
     -DLOCALSTATEDIR=/var \
     -DGVM_RUN_DIR=/run/gvm \
+    -DGVMD_RUN_DIR=/run/gvmd \
+    -DGSAD_RUN_DIR=/run/gsad \
     -DGSAD_PID_DIR=/run/gvm \
     -DLOGROTATE_DIR=/etc/logrotate.d
 

--- a/src/common/gvm-libs/build.rst
+++ b/src/common/gvm-libs/build.rst
@@ -8,7 +8,7 @@
     -DCMAKE_BUILD_TYPE=Release \
     -DSYSCONFDIR=/etc \
     -DLOCALSTATEDIR=/var \
-    -DGVM_PID_DIR=/run/gvm
+    -DGVM_RUN_DIR=/run/gvm
 
   make -j$(nproc)
 

--- a/src/common/gvmd/build.rst
+++ b/src/common/gvmd/build.rst
@@ -10,6 +10,7 @@
     -DSYSCONFDIR=/etc \
     -DGVM_DATA_DIR=/var \
     -DGVM_RUN_DIR=/run/gvm \
+    -DGVMD_RUN_DIR=/run/gvmd \
     -DOPENVAS_DEFAULT_SOCKET=/run/ospd/ospd-openvas.sock \
     -DGVM_FEED_LOCK_PATH=/var/lib/gvm/feed-update.lock \
     -DSYSTEMD_SERVICE_DIR=/lib/systemd/system \


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Update documentation to the current state of cmakefiles in GVM 21.4.

For gsad and gvmd there is `DGVMD_RUN_DIR` which is used in code.
For gsad `DGSAD_RUN_DIR` was introduced.
For gvm-libs `DGVM_PID_DIR` was replaced by `DGVM_RUN_DIR`

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
