### PR TITLE
fix gsad version variable

### DIFF
--- a/src/common/gsad/build.rst
+++ b/src/common/gsad/build.rst
@@ -3,7 +3,7 @@
 
   mkdir -p $BUILD_DIR/gsad && cd $BUILD_DIR/gsad
 
-  cmake $SOURCE_DIR/gsad-$GSA_VERSION \
+  cmake $SOURCE_DIR/gsad-$GSAD_VERSION \
     -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
     -DCMAKE_BUILD_TYPE=Release \
     -DSYSCONFDIR=/etc \


### PR DESCRIPTION
gsad build with wrong variable [GSA_VERSION](https://github.com/greenbone/docs/blob/c1ac9f51117171a1832db244c5d7906948dea33f/src/common/gsad/build.rst#L6), should be [GSAD_VERSION](https://github.com/greenbone/docs/blob/c1ac9f51117171a1832db244c5d7906948dea33f/src/common/gsad/version.rst#L4)