### PR TITLE
Fix command for updating the password of the admin user

### DIFF
--- a/src/21.04/container/index.md
+++ b/src/21.04/container/index.md
@@ -266,15 +266,15 @@ By default, a user *admin* with the password *admin* is created. This is insecur
 and it is highly recommended to set a new password.
 ```
 
-To create the administrator user with a password of your choice instead of the
+To update the administrator user with a password of your choice instead of the
 generated password, the following command can be used:
 
 ```{code-block} shell
 ---
-caption: Creating an administrator user with provided password
+caption: Updating password of administrator user
 ---
 docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u gvmd gvmd gvmd --create-user=admin --password=<password>
+    exec -u gvmd gvmd gvmd --user=admin --new-password=<password>
 ```
 ## Starting the Vulnerability Management
 


### PR DESCRIPTION
**What**:

When running the containers an admin user has been created already.
Therefore it is only possibly to update the password of the user.
Creating a new admin user will always fail.

**Why**:

Fix updating the password of the admin user

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
