### PR TITLE
Change: 21.04 is oldstable now

### DIFF
--- a/src/_static/docker-compose.yml
+++ b/src/_static/docker-compose.yml
@@ -10,19 +10,19 @@ services:
       - redis_socket_vol:/run/redis/
 
   gpg-data:
-    image: greenbone/gpg-data:latest
+    image: greenbone/gpg-data
     volumes:
       - gpg_data_vol:/mnt
 
   pg-gvm:
-    image: greenbone/pg-gvm:stable
+    image: greenbone/pg-gvm:oldstable
     restart: on-failure
     volumes:
       - psql_data_vol:/var/lib/postgresql
       - psql_socket_vol:/var/run/postgresql
 
   gvmd:
-    image: greenbone/gvmd:stable
+    image: greenbone/gvmd:oldstable
     restart: on-failure
     volumes:
       - gvmd_data_vol:/var/lib/gvm
@@ -35,7 +35,7 @@ services:
       - pg-gvm
 
   gsa:
-    image: greenbone/gsa:stable
+    image: greenbone/gsa:oldstable
     restart: on-failure
     ports:
       - 9392:80
@@ -45,7 +45,7 @@ services:
       - gvmd
 
   ospd-openvas:
-    image: greenbone/ospd-openvas:stable
+    image: greenbone/ospd-openvas:oldstable
     restart: on-failure
     cap_add:
       - NET_ADMIN # for capturing packages in promiscuous mode


### PR DESCRIPTION
**What**:

Until the release is ready and the docs are up to date use oldstable
label for the current docker compose file.


**Why**:

stable (22.04) needs adjustments in the docker compose file.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
