### PR TITLE
Fix: Adjust setup and start script for 22.4

### DIFF
--- a/src/21.4/container/index.md
+++ b/src/21.4/container/index.md
@@ -94,7 +94,7 @@ To execute the script following command must be run:
 ---
 caption: Run setup and start script
 ---
-$DOWNLOAD_DIR/setup-and-start-greenbone-community-edition.sh
+$DOWNLOAD_DIR/setup-and-start-greenbone-community-edition.sh 21.4
 ```
 
 ```{include} /common/container/workflows.md

--- a/src/22.4/container/index.md
+++ b/src/22.4/container/index.md
@@ -99,7 +99,7 @@ To execute the script following command needs to be run
 ---
 caption: Run setup and start script
 ---
-$DOWNLOAD_DIR/setup-and-start-greenbone-community-edition.sh
+$DOWNLOAD_DIR/setup-and-start-greenbone-community-edition.sh 22.4
 ```
 
 ```{include} /common/container/workflows.md

--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -7,8 +7,13 @@ DOWNLOAD_DIR=$HOME/greenbone-community-container
 TEST_CURL=$(curl --version)
 HAS_CURL=$?
 
+RELEASE="$1"
+if [ -z $RELEASE ]; then
+    RELEASE="22.4"
+fi
+
 if [ $HAS_CURL -gt 0 ]; then
-    echo "curl ist not available. See https://greenbone.github.io/docs/latest/21.04/container/#prerequisites."
+    echo "curl ist not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
     exit 1
 fi
 
@@ -16,46 +21,47 @@ TEST_DOCKER_COMPOSE=$(docker-compose --version)
 HAS_DOCKER_COMPOSE=$?
 
 if [ $HAS_DOCKER_COMPOSE -gt 0 ]; then
-    echo "docker-compose ist not available. See https://greenbone.github.io/docs/latest/21.04/container/#prerequisites."
+    echo "docker-compose ist not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
     exit 1
 fi
+
+echo "Using Greenbone Community Containers $RELEASE"
 
 mkdir -p $DOWNLOAD_DIR && cd $DOWNLOAD_DIR
 
 echo "Downloading docker-compose file..."
-curl -f -O https://greenbone.github.io/docs/latest/_static/docker-compose.yml
+curl -f -O https://greenbone.github.io/docs/latest/_static/docker-compose-$RELEASE.yml
 
-echo "Pulling Greenbone Community Containers..."
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition pull
-echo
-
-echo "Starting Greenbone Community Containers..."
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d
-echo
-
-echo "Waiting one minute for startup"
-sleep 1m
+echo "Pulling Greenbone Community Containers $RELEASE"
+docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition pull
 echo
 
 echo "Syncing the Greenbone Community Feed... (this takes a while)"
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u ospd-openvas ospd-openvas greenbone-nvt-sync
+docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition \
+    run --rm ospd-openvas greenbone-nvt-sync
 
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u gvmd gvmd greenbone-feed-sync --type SCAP
+docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition \
+    run --rm gvmd greenbone-feed-sync --type SCAP
 
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u gvmd gvmd greenbone-feed-sync --type CERT
+docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition \
+    run --rm gvmd greenbone-feed-sync --type CERT
 
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u gvmd gvmd greenbone-feed-sync --type GVMD_DATA
+docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition \
+    run --rm gvmd greenbone-feed-sync --type GVMD_DATA
 echo
 
+echo "Starting Greenbone Community Containers $RELEASE"
+docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition up -d
+echo
 
 read -s -p "Password for admin user: " password
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition \
     exec -u gvmd gvmd gvmd --user=admin --new-password=$password
-echo
 
-echo "Open Greenbone Security Assistant web interface in Browser to start scanning"
+echo
+echo "The synced feed data will be loaded now. This process may take several minutes up to hours."
+echo "Before the data isn't loaded completey scans will show insufficent or erroneous results."
+echo
+echo "Press enter to open Greenbone Security Assistant web interface in Browser"
+read
 xdg-open "http://127.0.0.1:9392" 2>/dev/null >/dev/null &

--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -62,6 +62,6 @@ echo
 echo "The synced feed data will be loaded now. This process may take several minutes up to hours."
 echo "Before the data is not loaded completely, scans will show insufficient or erroneous results."
 echo
-echo "Press Enter to open the Greenbone Security Assistant web interface in the web browser"
+echo "Press Enter to open the Greenbone Security Assistant web interface in the web browser."
 read
 xdg-open "http://127.0.0.1:9392" 2>/dev/null >/dev/null &

--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -13,7 +13,7 @@ if [ -z $RELEASE ]; then
 fi
 
 if [ $HAS_CURL -gt 0 ]; then
-    echo "curl ist not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
+    echo "curl is not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
     exit 1
 fi
 
@@ -21,7 +21,7 @@ TEST_DOCKER_COMPOSE=$(docker-compose --version)
 HAS_DOCKER_COMPOSE=$?
 
 if [ $HAS_DOCKER_COMPOSE -gt 0 ]; then
-    echo "docker-compose ist not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
+    echo "docker-compose is not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
     exit 1
 fi
 
@@ -60,8 +60,8 @@ docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-communi
 
 echo
 echo "The synced feed data will be loaded now. This process may take several minutes up to hours."
-echo "Before the data isn't loaded completey scans will show insufficent or erroneous results."
+echo "Before the data is not loaded completely, scans will show insufficient or erroneous results."
 echo
-echo "Press enter to open Greenbone Security Assistant web interface in Browser"
+echo "Press Enter to open the Greenbone Security Assistant web interface in the web browser"
 read
 xdg-open "http://127.0.0.1:9392" 2>/dev/null >/dev/null &

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -5,6 +5,9 @@ All notable changes to this documentation will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calendar Versioning](https://calver.org).
 
+## Latest
+* Fix Community Container setup and start script
+
 ## 22.7.0 – 2022-07-25
 * Update docs for supporting 22.4 release
 


### PR DESCRIPTION
**What**:

* Support both 21.4 and 22.4 with the script.
* Run the feed sync before starting the services. This avoids issues
  with the feed locking when ospd-openvas or gvmd already start loading
  the synced files. This could also be something worth for the community
  container guide.

**Why**:

Fix using the setup and start script for running the community containers

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
