### PR TITLE
Improve and extend feed sync chapters for community containers

### DIFF
--- a/src/21.4/container/index.md
+++ b/src/21.4/container/index.md
@@ -46,10 +46,29 @@ and their services in detail.
 | gsa | gsad | A container running the {term}`gsad` web server for providing the web application {term}`GSA`. The web interface is available at localhost on port 9392. For communication with gvmd, a unix socket in a volume is used. |
 | ospd-openvas | ospd-openvas | A container providing the vulnerability scanner. The VT data from the feed is stored in the `vt_data_vol` volume. To verify the feed data, the GPG keyring from the `gpg_data_vol` is used. The connection to the redis server is established via a unix socket in a volume. |
 
-```{include} /common/container/starting.md
+```{include} /common/container/performing-feed-sync.md
+```
+
+### Syncing Vulnerability Tests
+
+VT data contains {file}`.nasl` files for creating results during a vulnerability
+scan. The `.nasl` files are processed by the OpenVAS scanner.
+
+```{code-block} shell
+---
+caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while
+---
+docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+    run --rm ospd-openvas greenbone-nvt-sync
 ```
 
 ```{include} /common/container/feed-sync.md
+```
+
+```{include} /common/container/starting.md
+```
+
+```{include} /common/container/feed-loading.md
 ```
 
 ```{include} /common/container/admin-user.md

--- a/src/21.4/container/index.md
+++ b/src/21.4/container/index.md
@@ -52,11 +52,11 @@ and their services in detail.
 ### Syncing Vulnerability Tests
 
 VT data contains {file}`.nasl` files for creating results during a vulnerability
-scan. The `.nasl` files are processed by the OpenVAS scanner.
+scan. The `.nasl` files are processed by the OpenVAS Scanner.
 
 ```{code-block} shell
 ---
-caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while
+caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while.
 ---
 docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     run --rm ospd-openvas greenbone-nvt-sync

--- a/src/22.4/container/index.md
+++ b/src/22.4/container/index.md
@@ -49,11 +49,30 @@ and their services in detail.
 | mqtt-broker | [Mosquitto MQTT Broker](https://mosquitto.org/) | An MQTT Broker used for communication between notus-scanner, openvas-scanner and ospd-openvas. |
 | notus-scanner | notus-scanner | A container running the {term}`notus-scanner` used for local security checks. |
 
+```{include} /common/container/performing-feed-sync.md
+```
+
+### Syncing Vulnerability Tests
+
+VT data contains {file}`.nasl` and {file}`.notus` files for creating results
+during a vulnerability scan. The `.nasl` files are processed by the OpenVAS
+scanner and the `.notus` files by the {term}`Notus scanner <notus-scanner>`.
+
+```{code-block} shell
+---
+caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while
+---
+docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+    run --rm ospd-openvas greenbone-nvt-sync
+```
+
+```{include} /common/container/feed-sync.md
+```
 
 ```{include} /common/container/starting.md
 ```
 
-```{include} /common/container/feed-sync.md
+```{include} /common/container/feed-loading.md
 ```
 
 ```{include} /common/container/admin-user.md

--- a/src/22.4/container/index.md
+++ b/src/22.4/container/index.md
@@ -56,11 +56,11 @@ and their services in detail.
 
 VT data contains {file}`.nasl` and {file}`.notus` files for creating results
 during a vulnerability scan. The `.nasl` files are processed by the OpenVAS
-scanner and the `.notus` files by the {term}`Notus scanner <notus-scanner>`.
+Scanner and the `.notus` files by the {term}`Notus Scanner <notus-scanner>`.
 
 ```{code-block} shell
 ---
-caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while
+caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while.
 ---
 docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     run --rm ospd-openvas greenbone-nvt-sync

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ## Latest
 * Fix Community Container setup and start script
 * Fix installing yarn from third party debian package repository
+* Improve and extend feed sync chapters for community containers
 
 ## 22.7.0 – 2022-07-25
 * Update docs for supporting 22.4 release

--- a/src/common/container/feed-loading.md
+++ b/src/common/container/feed-loading.md
@@ -1,0 +1,129 @@
+## Loading the Feed Changes
+
+```{important}
+When feed content has been downloaded the new data needs to be loaded by the
+corresponding daemons. This may take several minutes up to hours especially
+for the initial loading of the data. Without loaded data scans will contain
+incomplete and errornous results.
+```
+
+After starting the Greenbone Community Containers the running daemons will pick
+up the feed content and load the data automatically.
+
+### Vulnerability Tests Data
+
+If the log (of ospd-openvas) contains the following output the OpenVAS
+scanner starts to load the new VT data:
+
+```{code-block} none
+---
+caption: ospd-openvas VT loading log message
+---
+Loading VTs. Scans will be [requested|queued] until VTs are loaded. This may
+take a few minutes, please wait...
+```
+
+The loading of the VT data is finished if the log message can be found:
+```{code-block} none
+---
+caption: ospd-openvas VTs loading finished log message
+---
+Finished loading VTs. The VT cache has been updated from version X to Y.
+```
+
+After the scanner is aware of the VT data it will be requested by gvmd. This
+will result in the following log message:
+
+```{code-block} none
+---
+caption: gvmd VTs loading log message
+---
+OSP service has different VT status (version X) from database (version (Y), Z VTs). Starting update ...
+```
+
+When gvmd has finished loading all VTs the following message appears:
+
+```{code-block} none
+---
+caption: gvmd VTs loading finished log message
+---
+Updating VTs in database ... done (X VTs).
+```
+
+### SCAP Data
+
+gvmd starts loading the {term}`SCAP` data containing {term}`CPE` and {term}`CVE`
+information when the following message can be found in the logs:
+
+```{code-block} none
+---
+caption: gvmd SCAP data loading log message
+---
+update_scap: Updating data from feed
+```
+
+The SCAP data is loaded and the synchronization is finished when the (gvmd) log
+contains the following message:
+
+```{code-block} none
+---
+caption: gvmd SCAP data loading finished log message
+---
+update_scap_end: Updating SCAP info succeeded
+```
+
+### CERT Data
+
+gvmd starts loading the CERT data containing DFN-Cert and CERT-Bund advisories
+when the following message can be found in the logs:
+
+```{code-block} none
+---
+caption: gvmd CERT data loading log message
+---
+sync_cert: Updating data from feed
+```
+
+The CERT data is loaded and the synchronization is finished when the (gvmd) log
+contains the following message:
+
+```{code-block} none
+---
+caption: gvmd CERT data finished loading log message
+---
+sync_cert: Updating CERT info succeeded.
+```
+
+### GVMD Data
+
+The log contains several messages when the gvmd data is loaded. For port lists
+these messages a similar to:
+
+```{code-block} none
+---
+caption: gvmd port list loaded log message
+---
+Port list All IANA assigned TCP (33d0cd82-57c6-11e1-8ed1-406186ea4fc5) has been created by admin
+```
+
+For report formats:
+
+```{code-block} none
+---
+caption: gvmd report format loaded log message
+---
+Report format XML (a994b278-1f62-11e1-96ac-406186ea4fc5) has been created by admin
+```
+
+```{hint}
+Scan Configs can only be loaded if the VT data is available in gvmd.
+```
+
+For scan configs:
+
+```{code-block} none
+---
+caption: gvmd scan config loaded log message
+---
+Scan config Full and fast (daba56c8-73ec-11df-a475-002264764cea) has been created by admin
+```

--- a/src/common/container/feed-loading.md
+++ b/src/common/container/feed-loading.md
@@ -7,7 +7,7 @@ for the initial loading of the data. Without loaded data, scans will contain
 incomplete and erroneous results.
 ```
 
-After starting the Greenbone Community Containers the running daemons will pick
+After starting the Greenbone Community Containers, the running daemons will pick
 up the feed content and load the data automatically.
 
 ### Vulnerability Tests Data

--- a/src/common/container/feed-loading.md
+++ b/src/common/container/feed-loading.md
@@ -1,10 +1,10 @@
 ## Loading the Feed Changes
 
 ```{important}
-When feed content has been downloaded the new data needs to be loaded by the
-corresponding daemons. This may take several minutes up to hours especially
-for the initial loading of the data. Without loaded data scans will contain
-incomplete and errornous results.
+When feed content has been downloaded, the new data needs to be loaded by the
+corresponding daemons. This may take several minutes up to hours, especially
+for the initial loading of the data. Without loaded data, scans will contain
+incomplete and erroneous results.
 ```
 
 After starting the Greenbone Community Containers the running daemons will pick
@@ -12,8 +12,8 @@ up the feed content and load the data automatically.
 
 ### Vulnerability Tests Data
 
-If the log (of ospd-openvas) contains the following output the OpenVAS
-scanner starts to load the new VT data:
+If the log (of ospd-openvas) contains the following output, the OpenVAS
+Scanner starts to load the new VT data:
 
 ```{code-block} none
 ---
@@ -31,7 +31,7 @@ caption: ospd-openvas VTs loading finished log message
 Finished loading VTs. The VT cache has been updated from version X to Y.
 ```
 
-After the scanner is aware of the VT data it will be requested by gvmd. This
+After the scanner is aware of the VT data, it will be requested by gvmd. This
 will result in the following log message:
 
 ```{code-block} none
@@ -41,7 +41,7 @@ caption: gvmd VTs loading log message
 OSP service has different VT status (version X) from database (version (Y), Z VTs). Starting update ...
 ```
 
-When gvmd has finished loading all VTs the following message appears:
+When gvmd has finished loading all VTs, the following message appears:
 
 ```{code-block} none
 ---
@@ -74,7 +74,7 @@ update_scap_end: Updating SCAP info succeeded
 
 ### CERT Data
 
-gvmd starts loading the CERT data containing DFN-Cert and CERT-Bund advisories
+gvmd starts loading the CERT data containing DFN-CERT and CERT-Bund advisories
 when the following message can be found in the logs:
 
 ```{code-block} none
@@ -96,8 +96,8 @@ sync_cert: Updating CERT info succeeded.
 
 ### GVMD Data
 
-The log contains several messages when the gvmd data is loaded. For port lists
-these messages a similar to:
+The log contains several messages when the gvmd data is loaded. For port lists,
+these messages are similar to:
 
 ```{code-block} none
 ---

--- a/src/common/container/feed-sync.md
+++ b/src/common/container/feed-sync.md
@@ -1,49 +1,4 @@
-## Performing a Feed Synchronization
-
-```{note}
-The duration of downloading the data during the synchronization depends on
-the network connection and server resources.
-```
-
-For the actual vulnerability scanning, {term}`Vulnerability Test scripts<VT>`,
-security information like CVEs, port lists and scan configurations are required.
-All this data is provided by the {term}`Greenbone Community Feed` and
-must be download initially before starting a vulnerability scan.
-
-```{note}
-A synchronization always consists of two parts:
-
-1. Downloading the changes via {command}`rsync`
-2. Loading the changes by a daemon into memory and a database
-
-Both steps may take a while, from several minutes up to hours. Especially for the
-initial synchronization. Only if both steps are finished, the synchronized data
-is up-to-date and can be used.
-```
-
-### Syncing Vulnerability Tests
-
-VT data contains {file}`.nasl` files for creating results during a vulnerability
-scan. The `.nasl` files are processed by the OpenVAS scanner.
-
-```{code-block} shell
----
-caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while
----
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u ospd-openvas ospd-openvas greenbone-nvt-sync
-```
-
 ### Syncing SCAP, CERT and GVMD Data
-
-```{note}
-If one of the following commands show `Sync in progress, exiting.`, a
-synchronization is still ongoing and `gvmd` may still load data. For example,
-if you find `gvmd: OSP: Updating NVT cache` in your processes list, the
-daemon is loading VT data from ospd-openvas. An additional process title can be
-`gvmd: Syncing SCAP: Updating CVEs`. In that case, you have to re-try after it
-has finished.
-```
 
 {term}`SCAP` data contains {term}`CPE` and {term}`CVE` information.
 
@@ -52,11 +7,8 @@ has finished.
 caption: Syncing SCAP data processed by gvmd, this will take a while
 ---
 docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u gvmd gvmd greenbone-feed-sync --type SCAP
+    run --rm gvmd greenbone-feed-sync --type SCAP
 ```
-
-The SCAP data is loaded and the synchronization is finished when the log
-contains the `update_scap_end: Updating SCAP info succeeded` message.
 
 CERT data contains vulnerability information from the German [DFN-CERT](https://www.dfn-cert.de/)
 and [CERT-Bund](https://cert-bund.de/) agencies.
@@ -66,11 +18,8 @@ and [CERT-Bund](https://cert-bund.de/) agencies.
 caption: Syncing CERT data processed by gvmd
 ---
 docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u gvmd gvmd greenbone-feed-sync --type CERT
+    run --rm gvmd greenbone-feed-sync --type CERT
 ```
-
-The CERT data is loaded and the synchronization is finished when the log
-contains the `sync_cert: Updating CERT info succeeded.` message.
 
 gvmd data (or also called data-objects) are scan configurations, compliance policies, port lists
 and report formats.
@@ -80,6 +29,5 @@ and report formats.
 caption: Syncing data objects processed by gvmd
 ---
 docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u gvmd gvmd greenbone-feed-sync --type GVMD_DATA
+    run --rm gvmd greenbone-feed-sync --type GVMD_DATA
 ```
-

--- a/src/common/container/performing-feed-sync.md
+++ b/src/common/container/performing-feed-sync.md
@@ -8,9 +8,9 @@ must be download and loaded initially before starting a vulnerability scan.
 A synchronization always consists of two parts:
 
 1. Downloading the changes via {command}`rsync`
-2. Loading the changes by a daemon into memory and a database
+2. The changes get loaded into memory and a database by a daemon
 
-Both steps may take a while, from several minutes up to hours. Especially for the
+Both steps may take a while, from several minutes up to hours, especially for the
 initial synchronization. Only if both steps are finished, the synchronized data
 is up-to-date and can be used.
 

--- a/src/common/container/performing-feed-sync.md
+++ b/src/common/container/performing-feed-sync.md
@@ -1,0 +1,25 @@
+## Performing a Feed Synchronization
+
+For the actual vulnerability scanning, {term}`Vulnerability Tests<VT>`,
+security information like CVEs, port lists and scan configurations are required.
+All this data is provided by the {term}`Greenbone Community Feed` and
+must be download and loaded initially before starting a vulnerability scan.
+
+A synchronization always consists of two parts:
+
+1. Downloading the changes via {command}`rsync`
+2. Loading the changes by a daemon into memory and a database
+
+Both steps may take a while, from several minutes up to hours. Especially for the
+initial synchronization. Only if both steps are finished, the synchronized data
+is up-to-date and can be used.
+
+The first step is done via the greenbone-nvt-sync and greenbone-feed-sync
+scripts. The second step is done automatically when the daemons are started.
+
+## Downloading the Feed Changes
+
+```{note}
+The duration of downloading the data during the synchronization depends on
+the network connection and server resources.
+```


### PR DESCRIPTION
**What**:

Split feed sync into the download of the data via the sync scripts and
the loading of the data by the daemons. This improves the situation when
ospd-openvas exists while trying to load an incomplete VT sync.

**Why**:

The containers may have issues during startup otherwise (https://community.greenbone.net/t/22-4-docker-ospd-openvas-shut-down/12653)

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
