### PR TITLE
Use latest openvas-smb 22.4.0 release for both community releases

### DIFF
--- a/src/changelog.md
+++ b/src/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Fix Community Container setup and start script
 * Fix installing yarn from third party debian package repository
 * Improve and extend feed sync chapters for community containers
+* Use openvas-smb 22.4.0 for both releases
 
 ## 22.7.0 – 2022-07-25
 * Update docs for supporting 22.4 release

--- a/src/common/source-build/openvas-smb.rst
+++ b/src/common/source-build/openvas-smb.rst
@@ -14,7 +14,7 @@ Windows-based systems.
 .. code-block::
   :caption: Setting the openvas-smb version to use
 
-  export OPENVAS_SMB_VERSION=21.4.0
+  export OPENVAS_SMB_VERSION=22.4.0
 
 .. code-block::
   :caption: Required dependencies for openvas-smb


### PR DESCRIPTION
**What**:

openvas-smb is released independently from the community releases. It is
compatible to both 21.4 and 22.4.

**Why**:

Use latest openvas-smb release.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
