### PR TITLE
Fix: Fix path to the product advisories for notus-scanner container

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -88,7 +88,7 @@ services:
       - gpg_data_vol:/etc/openvas/gnupg
     environment:
       NOTUS_SCANNER_MQTT_BROKER_ADDRESS: mqtt-broker
-      NOTUS_SCANNER_PRODUCTS_DIRECTORY: /var/lib/notus
+      NOTUS_SCANNER_PRODUCTS_DIRECTORY: /var/lib/notus/products
     depends_on:
       - mqtt-broker
       - gpg-data


### PR DESCRIPTION
**What**:

Fix path to the product advisories for notus-scanner container

**Why**:

The path must be `/var/lib/notus/products`.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] CHANGELOG.md entry
- [x] Documentation
