### PR TITLE
Add: Provde gvm-tools container for 21.4 and 22.4

### DIFF
--- a/src/21.4/container/index.md
+++ b/src/21.4/container/index.md
@@ -48,6 +48,7 @@ and their services in detail.
 | gvmd | gvmd | A container for {term}`gvmd` that uses unix sockets in volumes to communicate with the PostgreSQL database and ospd-openvas scanner. The downloaded feed data is stored in the `gvmd_data_vol` volume. To verify the feed data, the GPG keyring from the `gpg_data_vol` is used. |
 | gsa | gsad | A container running the {term}`gsad` web server for providing the web application {term}`GSA`. The web interface is available at localhost on port 9392. For communication with gvmd, a unix socket in a volume is used. |
 | ospd-openvas | ospd-openvas | A container providing the vulnerability scanner. The VT data from the feed is stored in the `vt_data_vol` volume. To verify the feed data, the GPG keyring from the `gpg_data_vol` is used. The connection to the redis server is established via a unix socket in a volume. |
+| gvm-tools | | A container providing the [gvm-tools](https://github.com/greenbone/gvm-tools/) CLI to query and control gvmd and ospd-openvas. |
 
 ```{include} /common/container/performing-feed-sync.md
 ```

--- a/src/22.4/container/index.md
+++ b/src/22.4/container/index.md
@@ -51,6 +51,7 @@ and their services in detail.
 | ospd-openvas | ospd-openvas | A container providing the vulnerability scanner. The VT data from the feed is stored in the `vt_data_vol` volume. To verify the feed data, the GPG keyring from the `gpg_data_vol` is used. The connection to the redis server is established via a unix socket in a volume. |
 | mqtt-broker | [Mosquitto MQTT Broker](https://mosquitto.org/) | An MQTT Broker used for communication between notus-scanner, openvas-scanner and ospd-openvas. |
 | notus-scanner | notus-scanner | A container running the {term}`notus-scanner` used for local security checks. To verify the feed data, the GPG keyring from the `gpg_data_vol` is used. The feed data for notus-scanner itself is stored in the `notus_data_vol`. |
+| gvm-tools | | A container providing the [gvm-tools](https://github.com/greenbone/gvm-tools/) CLI to query and control gvmd and ospd-openvas. |
 
 ```{include} /common/container/performing-feed-sync.md
 ```

--- a/src/_static/docker-compose-21.4.yml
+++ b/src/_static/docker-compose-21.4.yml
@@ -60,6 +60,15 @@ services:
       - redis-server
       - gpg-data
 
+  gvm-tools:
+    image: greenbone/gvm-tools
+    volumes:
+      - gvmd_socket_vol:/run/gvmd
+      - ospd_openvas_socket_vol:/run/ospd
+    depends_on:
+      - gvmd
+      - ospd-openvas
+
 volumes:
   gpg_data_vol:
   gvmd_data_vol:

--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -89,9 +89,19 @@ services:
     environment:
       NOTUS_SCANNER_MQTT_BROKER_ADDRESS: mqtt-broker
       NOTUS_SCANNER_PRODUCTS_DIRECTORY: /var/lib/notus/products
+      NOTUS_SCANNER_LOG_LEVEL: debug
     depends_on:
       - mqtt-broker
       - gpg-data
+
+  gvm-tools:
+    image: greenbone/gvm-tools
+    volumes:
+      - gvmd_socket_vol:/run/gvmd
+      - ospd_openvas_socket_vol:/run/ospd
+    depends_on:
+      - gvmd
+      - ospd-openvas
 
 volumes:
   gpg_data_vol:

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Add an API page for links to our other community documentation
 * Fix path of the notus-scanner product advisories directory for the 22.4
   container setup
+* Add gvm-tools container and usage workflow documentation
 
 ## 22.8.0 - 2022-08-16
 * Fix Community Container setup and start script

--- a/src/common/container/workflows.md
+++ b/src/common/container/workflows.md
@@ -52,7 +52,7 @@ Afterwards, you can execute standard bash commands within the running container.
 
 ### Use gvm-tools for CLI access
 
-To query data or control gvmd and ospd-openvas via CLI [gvm-tools](https://github.com/greenbone/gvm-tools/)
+To query data or control gvmd and ospd-openvas via CLI, [gvm-tools](https://github.com/greenbone/gvm-tools/)
 can be used. gvm-tools is provided in the gvm-tools container. This container
 can be started with:
 
@@ -63,8 +63,8 @@ caption: Start container for gvm-tools CLI access
 docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition run --rm gvm-tools
 ```
 
-Afterwards a bash shell is provided and `gvm-cli`, `gvm-pyshell` or `gvm-script`
-can be run. For example
+Afterwards, a bash shell is provided and `gvm-cli`, `gvm-pyshell` or `gvm-script`
+can be run. For example:
 
 ```{code-block} shell
 ---

--- a/src/common/container/workflows.md
+++ b/src/common/container/workflows.md
@@ -50,6 +50,29 @@ docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-editio
 
 Afterwards, you can execute standard bash commands within the running container.
 
+### Use gvm-tools for CLI access
+
+To query data or control gvmd and ospd-openvas via CLI [gvm-tools](https://github.com/greenbone/gvm-tools/)
+can be used. gvm-tools is provided in the gvm-tools container. This container
+can be started with:
+
+```{code-block} shell
+---
+caption: Start container for gvm-tools CLI access
+---
+docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition run --rm gvm-tools
+```
+
+Afterwards a bash shell is provided and `gvm-cli`, `gvm-pyshell` or `gvm-script`
+can be run. For example
+
+```{code-block} shell
+---
+caption: Query gvmd version via gvm-cli
+---
+gvm-cli --gmp-username admin socket --pretty --xml "<get_version/>"
+```
+
 ### Expose gvmd Unix Socket for GMP access
 
 To allow using the {term}`GMP` protocol provided by {term}`gvmd` from the docker


### PR DESCRIPTION
**What**:

Provde gvm-tools container for 21.4 and 22.4

DEVOPS-347

**Why**:

Allow querying and controlling gvmd and ospd-openvas easily via
gvm-tools CLI.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] CHANGELOG.md entry
- [x] Documentation
