### PR TITLE
Change: Use same unix command to add current user to the docker group

### DIFF
--- a/src/common/container/prerequisites.md
+++ b/src/common/container/prerequisites.md
@@ -103,16 +103,9 @@ effective, either logout and login again or use {command}`su`.
 
 ```{code-block} shell
 ---
-caption: Add current user to docker group
+caption: Add current user to docker group and  apply group changes for the current shell environment
 ---
-sudo usermod -aG docker $USER
-```
-
-```{code-block} shell
----
-caption: Apply group changes for the current shell environment
----
-su $USER
+sudo usermod -aG docker $USER && su $USER
 ```
 
 For downloading the Greenbone Community Edition docker compose file, a

--- a/src/common/container/prerequisites.md
+++ b/src/common/container/prerequisites.md
@@ -101,25 +101,12 @@ To allow the current user to run {command}`docker` and therefore start the
 containers, they must be added to the *docker* user group. To make the group change
 effective, either logout and login again or use {command}`su`.
 
-`````{tabs}
-````{tab} Debian/Ubuntu
-```{code-block} shell
----
-caption: Add current user to docker group
----
-sudo adduser $USER docker
-```
-````
-````{tab} Fedora/CentOS
 ```{code-block} shell
 ---
 caption: Add current user to docker group
 ---
 sudo usermod -aG docker $USER
 ```
-````
-`````
-
 
 ```{code-block} shell
 ---


### PR DESCRIPTION
**What**:

Use same unix command to add current user to the docker group

**Why**:

It seems adduser is Debian specific and to simplify adding the current
user to the docker group use the usermod command for all distributions
instead. This command is available on all distributions.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
