### PR TITLE
Change: Use notus-scanner and ospd-openvas 22.4.1

### DIFF
--- a/src/22.4/source-build/index.rst
+++ b/src/22.4/source-build/index.rst
@@ -121,7 +121,7 @@ ospd-openvas
 .. code-block::
   :caption: Setting the ospd and ospd-openvas versions to use
 
-  export OSPD_OPENVAS_VERSION=$GVM_VERSION
+  export OSPD_OPENVAS_VERSION=22.4.1
 
 .. include:: /22.4/source-build/ospd-openvas/dependencies.rst
 .. include:: /common/source-build/ospd-openvas/download.rst
@@ -135,7 +135,7 @@ notus-scanner
 .. code-block::
   :caption: Setting the notus version to use
 
-  export NOTUS_VERSION=$GVM_VERSION
+  export NOTUS_VERSION=22.4.1
 
 .. include:: /22.4/source-build/notus-scanner/dependencies.rst
 .. include:: /22.4/source-build/notus-scanner/download.rst

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
   Container docs
 * Require docker-compose 1.27.0 or later to avoid issues with the ospd-openvas
   startup
+* Use notus-scanner 22.4.1 and ospd-openvas 22.4.1 for 22.4 source build
 
 ## 22.8.1 - 2022-08-29
 * Add workflow for exposing the gvmd unix socket from the container


### PR DESCRIPTION
**What**:

Use notus-scanner and ospd-openvas 22.4.1

**Why**:

Use newest releases of notus-scanner and ospd-openvas 22.4.1 for 22.4
source build.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
