### PR TITLE
Fix: Add missing executable permission for setup script

### DIFF
--- a/src/21.4/container/index.md
+++ b/src/21.4/container/index.md
@@ -98,7 +98,7 @@ script can be downloaded with the following command directly:
 ---
 caption: Downloading setup and start script
 ---
-cd $DOWNLOAD_DIR && curl -f -O https://greenbone.github.io/docs/latest/_static/setup-and-start-greenbone-community-edition.sh
+cd $DOWNLOAD_DIR && curl -f -O https://greenbone.github.io/docs/latest/_static/setup-and-start-greenbone-community-edition.sh && chmod u+x setup-and-start-greenbone-community-edition.sh
 ```
 
 To execute the script following command must be run:

--- a/src/22.4/container/index.md
+++ b/src/22.4/container/index.md
@@ -102,7 +102,7 @@ script can be downloaded with the following command directly:
 ---
 caption: Downloading setup and start script
 ---
-cd $DOWNLOAD_DIR && curl -f -O https://greenbone.github.io/docs/latest/_static/setup-and-start-greenbone-community-edition.sh
+cd $DOWNLOAD_DIR && curl -f -O https://greenbone.github.io/docs/latest/_static/setup-and-start-greenbone-community-edition.sh && chmod u+x setup-and-start-greenbone-community-edition.sh
 ```
 
 To execute the script following command needs to be run

--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -17,6 +17,14 @@ if [ $HAS_CURL -gt 0 ]; then
     exit 1
 fi
 
+TEST_DOCKER=$(docker --version)
+HAS_DOCKER=$?
+
+if [ $HAS_DOCKER_COMPOSE -gt 0 ]; then
+    echo "docker is not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
+    exit 1
+fi
+
 TEST_DOCKER_COMPOSE=$(docker-compose --version)
 HAS_DOCKER_COMPOSE=$?
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this documentation will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calendar Versioning](https://calver.org).
 
+## Latest
+* Fix setting executable permission for setup and install script after the
+  download
+* Check for docker being installed in setup and install script
+
 ## 22.8.2 – 22-08-31
 * Improve feed sync documentation for source build
 * Use feed data containers for feed sync in Greenbone Community Containers docs


### PR DESCRIPTION
**What**:

Add the missing executable permission for the downloaded setup and
install script.

**Why**:

Without execute permissions the script can't be run.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
