### PR TITLE
Change: Update systemd service file for gsad to start in foreground

### DIFF
--- a/src/21.4/source-build/systemd.rst
+++ b/src/21.4/source-build/systemd.rst
@@ -78,13 +78,13 @@ Setting up Services for *Systemd*
   Wants=gvmd.service
 
   [Service]
-  Type=forking
+  Type=exec
   User=gvm
   Group=gvm
   RuntimeDirectory=gsad
   RuntimeDirectoryMode=2775
   PIDFile=/run/gsad/gsad.pid
-  ExecStart=/usr/local/sbin/gsad --listen=127.0.0.1 --port=9392 --http-only
+  ExecStart=/usr/local/sbin/gsad --foreground --listen=127.0.0.1 --port=9392 --http-only
   Restart=always
   TimeoutStopSec=10
 

--- a/src/22.4/source-build/systemd.rst
+++ b/src/22.4/source-build/systemd.rst
@@ -109,13 +109,13 @@ Setting up Services for *Systemd*
   Wants=gvmd.service
 
   [Service]
-  Type=forking
+  Type=exec
   User=gvm
   Group=gvm
   RuntimeDirectory=gsad
   RuntimeDirectoryMode=2775
   PIDFile=/run/gsad/gsad.pid
-  ExecStart=/usr/local/sbin/gsad --listen=127.0.0.1 --port=9392 --http-only
+  ExecStart=/usr/local/sbin/gsad --foreground --listen=127.0.0.1 --port=9392 --http-only
   Restart=always
   TimeoutStopSec=10
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -15,8 +15,9 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Fix the checks for required programs in the setup script
 * Use ospd-openvas 22.4.2 for 22.4 source build
 * Add HTML and Open Graph meta information
-* Fix: Add -i to the rm -rf statements, to not accidently delete unwanted files
 * Fix: Remove -rf statements within `$INSTAL_DIR` to prevent deletion of root.
+* Update gsad systemd service file to start gsad in foreground to avoid issues
+  with systemd tracking the started processes
 
 ## 22.8.2 – 22-08-31
 * Improve feed sync documentation for source build


### PR DESCRIPTION
**What**:

It may happen that due to forking the background processes systemd isn't able to track the running processes of gsad. To avoid this situation gsad can be started in foreground.

See https://github.com/greenbone/gsad/pull/84 for some more details.

**Why**:

systemd might not be able to track gsad processes when using forking.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
