### PR TITLE
Add: docker init process to to prevent nmap, grep zombie processes

### DIFF
--- a/src/_static/docker-compose-21.4.yml
+++ b/src/_static/docker-compose-21.4.yml
@@ -93,6 +93,7 @@ services:
   ospd-openvas:
     image: greenbone/ospd-openvas:oldstable
     restart: on-failure
+    init: true
     cap_add:
       - NET_ADMIN # for capturing packages in promiscuous mode
       - NET_RAW # for raw sockets e.g. used for the boreas alive detection

--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -98,6 +98,7 @@ services:
   ospd-openvas:
     image: greenbone/ospd-openvas:stable
     restart: on-failure
+    init: true
     cap_add:
       - NET_ADMIN # for capturing packages in promiscuous mode
       - NET_RAW # for raw sockets e.g. used for the boreas alive detection

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -18,6 +18,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Fix: Remove -rf statements within `$INSTAL_DIR` to prevent deletion of root.
 * Update gsad systemd service file to start gsad in foreground to avoid issues
   with systemd tracking the started processes
+* Add: docker init process to prevent nmap, grep zombie processes in the
+  ospd-openvas container
 
 ## 22.8.2 – 22-08-31
 * Improve feed sync documentation for source build


### PR DESCRIPTION
**What**:
Use docker-init as pid 1 process to prevent nmap, grep zombie processes.
It starts the docker cmd with the docker-init process which handles the zombie process.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
After some testing, i saw a lot of zombie nmap zombie process pop up, docker-init process prevent this.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] CHANGELOG.md entry
- [x] Documentation
