### PR TITLE
…Add: hostname to ospd-openvas container

### DIFF
--- a/src/_static/docker-compose-21.4.yml
+++ b/src/_static/docker-compose-21.4.yml
@@ -94,6 +94,7 @@ services:
     image: greenbone/ospd-openvas:oldstable
     restart: on-failure
     init: true
+    hostname: ospd-openvas.local
     cap_add:
       - NET_ADMIN # for capturing packages in promiscuous mode
       - NET_RAW # for raw sockets e.g. used for the boreas alive detection

--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -99,6 +99,7 @@ services:
     image: greenbone/ospd-openvas:stable
     restart: on-failure
     init: true
+    hostname: ospd-openvas.local
     cap_add:
       - NET_ADMIN # for capturing packages in promiscuous mode
       - NET_RAW # for raw sockets e.g. used for the boreas alive detection

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -22,6 +22,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
   ospd-openvas container
 * Add troubleshooting for ospd-openvas connection issue with containers
 * Add troubleshooting pages for source builds
+* Add hostname to ospd-openvas container, to avoid error
+  Could not get a bpf, ethernet address used in non-ether expression
 
 ## 22.8.2 – 22-08-31
 * Improve feed sync documentation for source build


### PR DESCRIPTION
Add: hostname to ospd-openvas container, to avoid error Could not get a bpf, ethernet address used in non-ether expression

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Errors like this:
lib  nasl:MESSAGE:2022-10-01 04h17.18 utc:11820: [11820](/var/lib/openvas/plugins/2021/apache/gb_log4j_CVE-2021-44228_tcp_active.nasl:135) pcap_next: Could not get a bpf

lib  misc:MESSAGE:2022-10-01 04h17.18 utc:11820: [gb_log4j_CVE-2021-44228_tcp_active.nasl] pcap_compile: Filter "tcp and dst port 18985 and src host *** and (dst host 172.18.0.7 or dst host c4cc73489cdc)" : ethernet address used in non-ether expression
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
