### PR TITLE
Background for tabs in light theme, pointer instead of cursor on tabs

### DIFF
--- a/src/_static/custom.css
+++ b/src/_static/custom.css
@@ -26,6 +26,11 @@ div.body h6 {
 .sphinx-tabs-tab {
 	color:var(--color-content-foreground);
 	font-family: Helvetica, Verdana;
+	cursor: pointer;
+}
+
+.sphinx-tabs-tab[aria-selected="false"] {
+	background-color: rgba(0, 0, 0, 0.05);
 }
 
 a {


### PR DESCRIPTION
**What**:

Added background to tabs in light theme. Changed cursor to pointer for tabs.
