### PR TITLE
Change: Don't use `--prefix` argument with pip

### DIFF
--- a/src/22.4/source-build/notus-scanner/build.rst
+++ b/src/22.4/source-build/notus-scanner/build.rst
@@ -3,8 +3,7 @@
 
   cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
 
-  python3 -m pip install . --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR --no-warn-script-location
+  python3 -m pip install . --root=$INSTALL_DIR --no-warn-script-location
 
   sudo cp -rv $INSTALL_DIR/* /
 
-  

--- a/src/common/source-build/gvm-tools/install.rst
+++ b/src/common/source-build/gvm-tools/install.rst
@@ -12,8 +12,7 @@ commands can be used:
 .. code-block::
   :caption: Installing gvm-tools system-wide
 
-  python3 -m pip install --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR --no-warn-script-location gvm-tools
+  python3 -m pip install --root=$INSTALL_DIR --no-warn-script-location gvm-tools
 
   sudo cp -rv $INSTALL_DIR/* /
 
-  

--- a/src/common/source-build/ospd-openvas/build.rst
+++ b/src/common/source-build/ospd-openvas/build.rst
@@ -3,8 +3,7 @@
 
   cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
 
-  python3 -m pip install . --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR --no-warn-script-location
+  python3 -m pip install . --root=$INSTALL_DIR --no-warn-script-location
 
   sudo cp -rv $INSTALL_DIR/* /
 
-  


### PR DESCRIPTION
**What**:

Don't use `--prefix` argument with pip for installing ospd-openvas, notus-scanner and gvm-tools.

**Why**:

Using the `--prefix` argument is broken with newer pip versions and at least Python 3.10. The distros are patching CPython's sysconfig module which breaks our expected behavior for the `--prefix` argument. Because the default install prefix is already `/usr/local` we just can remove the `--prefix` argument to circumvent the bug.

See the following links for details:

* https://github.com/pypa/pip/issues/11651
* https://github.com/pypa/pip/issues/10978
* https://discuss.python.org/t/linux-distro-patches-to-sysconfig-are-changing-pip-install-prefix-outside-virtual-environments/18240

**How**:

Tested on a Ubuntu 22.04 container image with packaged Python and pip.
