### PR TITLE
Change: Update docker compose requirement to 1.29.0

### DIFF
--- a/src/changelog.md
+++ b/src/changelog.md
@@ -25,6 +25,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Add hostname to ospd-openvas container, to avoid error
   Could not get a bpf, ethernet address used in non-ether expression
 * Extend troubleshooting for source build
+* Update docker compose requirement to 1.29.0
 
 ## 22.8.2 – 22-08-31
 * Improve feed sync documentation for source build

--- a/src/common/container/prerequisites.md
+++ b/src/common/container/prerequisites.md
@@ -70,7 +70,7 @@ sudo dnf install -y docker-ce docker-ce-cli containerd.io
 
 ### Installing docker-compose
 
-[docker-compose] version 1.27.0 or newer is required for starting and connecting
+[docker-compose] version 1.29.0 or newer is required for starting and connecting
 the services of the Greenbone Community Edition. The description of the service
 orchestration is done by using [compose files](https://docs.docker.com/compose/compose-file/).
 A compose file for the Greenbone Community Edition is provided later on.


### PR DESCRIPTION
**What**:

Update docker compose requirement to 1.29.0

See https://github.com/docker/compose/releases/tag/1.29.0 and https://github.com/docker/compose/issues/8154

Closes #230

**Why**:

The `depends_on` `service_completed_successfully` config in the compose file requires docker compose 1.29.0 actually.