### PR TITLE
Fix: Fix installing ospd-openvas and notus-scanner on Debian 11

### DIFF
--- a/src/22.4/source-build/notus-scanner/build.rst
+++ b/src/22.4/source-build/notus-scanner/build.rst
@@ -1,9 +1,21 @@
-.. code-block::
-  :caption: Installing notus-scanner
+.. tabs::
+  .. tab:: Debian/CentOS
+    .. code-block::
+      :caption: Installing notus-scanner
 
-  cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
+      cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
 
-  python3 -m pip install . --root=$INSTALL_DIR --no-warn-script-location
+      python3 -m pip install . --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR --no-warn-script-location
 
-  sudo cp -rv $INSTALL_DIR/* /
+      sudo cp -rv $INSTALL_DIR/* /
+
+  .. tab:: Ubuntu/Fedora
+    .. code-block::
+      :caption: Installing notus-scanner
+
+      cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
+
+      python3 -m pip install . --root=$INSTALL_DIR --no-warn-script-location
+
+      sudo cp -rv $INSTALL_DIR/* /
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## Latest
+* Fix installing ospd-openvas and notus-scanner on Debian 11
 
 ## 22.12.0 – 22-12-27
 * Fix setting executable permission for setup and install script after the

--- a/src/common/source-build/ospd-openvas/build.rst
+++ b/src/common/source-build/ospd-openvas/build.rst
@@ -1,9 +1,21 @@
-.. code-block::
-  :caption: Installing ospd-openvas
+.. tabs::
+  .. tab:: Debian/CentOS
+    .. code-block::
+      :caption: Installing ospd-openvas
 
-  cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
+      cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
 
-  python3 -m pip install . --root=$INSTALL_DIR --no-warn-script-location
+      python3 -m pip install . --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR --no-warn-script-location
 
-  sudo cp -rv $INSTALL_DIR/* /
+      sudo cp -rv $INSTALL_DIR/* /
+
+  .. tab:: Ubuntu/Fedora
+    .. code-block::
+      :caption: Installing ospd-openvas
+
+      cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
+
+      python3 -m pip install . --root=$INSTALL_DIR --no-warn-script-location
+
+      sudo cp -rv $INSTALL_DIR/* /
 


### PR DESCRIPTION
**What**:

Follow up of ff8861133fd173029d6651fdcdb6ecd31159d319 where the `--prefix` argument got removed from the pip install command. It seems that older pip versions behave again differently and use `--user` as default when prefix is missing. Therefore the Python code got installed into `$INSTALL_DIR/home/$USER/.local/lib/python3.X/`. To fix that the `--prefix` argument is introduced again for the older distros.

Background https://forum.greenbone.net/t/notus-installed-to-wrong-location/13767

**Why**:

Fix installation on Debian 11.