### PR TITLE
Fix: Set `table_driven_lsc = yes` for openvas-scanner in source build

### DIFF
--- a/src/22.4/source-build/mqtt-broker.rst
+++ b/src/22.4/source-build/mqtt-broker.rst
@@ -25,4 +25,4 @@ and the server uri must be added to the *openvas-scanner* configuration.
 
   sudo systemctl start mosquitto.service
   sudo systemctl enable mosquitto.service
-  echo "mqtt_server_uri = localhost:1883" | sudo tee -a /etc/openvas/openvas.conf
+  echo "mqtt_server_uri = localhost:1883\ntable_driven_lsc = yes" | sudo tee -a /etc/openvas/openvas.conf

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -5,6 +5,10 @@ All notable changes to this documentation will be listed in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calendar Versioning](https://calver.org).
 
+## Latest
+* Set `table_drive_lsc = yes` setting for openvas scanner to enable local
+  security checks scanning via notus scanner
+
 ## 23.1.0 - 23-01-13
 * Fix installing ospd-openvas and notus-scanner on Debian 11
 * Update components to 22.4.1 release


### PR DESCRIPTION
## What

Set `table_driven_lsc = yes` for openvas-scanner in source build

## Why

Enable lsc scanning via notus-scanner.


## References

https://forum.greenbone.net/t/notus-scanner-doesnt-seem-to-be-used-during-scan/13189