### PR TITLE
Change: Use exec mode for gvmd in systemd service file

### DIFF
--- a/src/22.4/source-build/systemd.rst
+++ b/src/22.4/source-build/systemd.rst
@@ -79,13 +79,13 @@ Setting up Services for *Systemd*
   ConditionKernelCommandLine=!recovery
 
   [Service]
-  Type=forking
+  Type=exec
   User=gvm
   Group=gvm
   PIDFile=/run/gvmd/gvmd.pid
   RuntimeDirectory=gvmd
   RuntimeDirectoryMode=2775
-  ExecStart=/usr/local/sbin/gvmd --osp-vt-update=/run/ospd/ospd-openvas.sock --listen-group=gvm
+  ExecStart=/usr/local/sbin/gvmd --foreground --osp-vt-update=/run/ospd/ospd-openvas.sock --listen-group=gvm
   Restart=always
   TimeoutStopSec=10
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -10,6 +10,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
   security checks scanning via notus scanner
 * Remove docs for 21.04 because it is end-of-life and wont get any updates
   anymore.
+* Update gvmd systemd service file to start gvmd in foreground to avoid issues
+  with systemd tracking the started processes
 
 ## 23.1.0 - 23-01-13
 * Fix installing ospd-openvas and notus-scanner on Debian 11


### PR DESCRIPTION
## What

 Update gvmd systemd service file to start gvmd in foreground to avoid
 issues with systemd tracking the started processes. It seems that
 forking causes a lot of stange issues. For example
 
## Why

Avoid startup issues of gvmd.

## References

https://forum.greenbone.net/t/debian11-gvm-22-4-gvmd-service-cant-open-pid-file-run-gvmd-gvmd-pid-yet-after-start-operation-not-permitted/13886
https://github.com/greenbone/gsad/pull/84


