### PR TITLE
Various updates to the FAQ for no scan results

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -116,18 +116,18 @@ Some common issues if scans doesn't return any results are:
    **Alive Test** setting of your target definition and try some of the other
    available methods. Further reading:
 
-    [Greenbone Enterprise Appliance documentation - Hosts not found](https://docs.greenbone.net/GSM-Manual/gos-22.04/en/scanning.html#hosts-not-found)
-    [Greenbone Enterprise Appliance documentation - Creating a target](https://docs.greenbone.net/GSM-Manual/gos-22.04/en/scanning.html#creating-a-target)
+   - [Greenbone Enterprise Appliance documentation - Hosts not found](https://docs.greenbone.net/GSM-Manual/gos-22.04/en/scanning.html#hosts-not-found)
+   - [Greenbone Enterprise Appliance documentation - Creating a target](https://docs.greenbone.net/GSM-Manual/gos-22.04/en/scanning.html#creating-a-target)
 
 2. You're using a custom scan configuration which doesn't include the following
    two VTs from the **Port scanners** family.
 
-    [Nmap (NASL wrapper) - OID: 1.3.6.1.4.1.25623.1.0.14259](https://secinfo.greenbone.net/omp?cmd=get_info&info_type=nvt&info_id=1.3.6.1.4.1.25623.1.0.14259&token=guest)
-    [Ping Host - OID: 1.3.6.1.4.1.25623.1.0.100315](https://secinfo.greenbone.net/omp?cmd=get_info&info_type=nvt&info_id=1.3.6.1.4.1.25623.1.0.100315&token=guest)
+   - [Nmap (NASL wrapper) - OID: 1.3.6.1.4.1.25623.1.0.14259](https://secinfo.greenbone.net/omp?cmd=get_info&info_type=nvt&info_id=1.3.6.1.4.1.25623.1.0.14259&token=guest)
+   - [Ping Host - OID: 1.3.6.1.4.1.25623.1.0.100315](https://secinfo.greenbone.net/omp?cmd=get_info&info_type=nvt&info_id=1.3.6.1.4.1.25623.1.0.100315&token=guest)
 
     Further reading [here](https://community.greenbone.net/t/hint-self-created-scan-configs-copy-of-empty-scan-config-showing-no-results/331)
 
-3. You're using a [Port List](https://docs.greenbone.net/GSM-Manual/gos-4/en/performance.html#selecting-a-port-list-for-a-scan)
+3. You're using a [Port List](https://docs.greenbone.net/GSM-Manual/gos-22.04/en/performance.html#selecting-a-port-list-for-a-task)
    which isn't optimal for your environment:
 
     e.g. a ``All TCP and All UDP`` port list might be responsible for your

--- a/src/faq.md
+++ b/src/faq.md
@@ -123,8 +123,8 @@ Some common issues if scans doesn't return any results are:
 2. You're using a custom scan configuration which doesn't include the following
    two VTs from the **Port scanners** family.
 
-   - [Nmap (NASL wrapper) - OID: 1.3.6.1.4.1.25623.1.0.14259](https://secinfo.greenbone.net/omp?cmd=get_info&info_type=nvt&info_id=1.3.6.1.4.1.25623.1.0.14259&token=guest)
-   - [Ping Host - OID: 1.3.6.1.4.1.25623.1.0.100315](https://secinfo.greenbone.net/omp?cmd=get_info&info_type=nvt&info_id=1.3.6.1.4.1.25623.1.0.100315&token=guest)
+   - [Nmap (NASL wrapper) - OID: 1.3.6.1.4.1.25623.1.0.14259](https://secinfo.greenbone.net/nvt/1.3.6.1.4.1.25623.1.0.14259)
+   - [Ping Host - OID: 1.3.6.1.4.1.25623.1.0.100315](https://secinfo.greenbone.net/nvt/1.3.6.1.4.1.25623.1.0.100315)
 
     Further reading [here](https://community.greenbone.net/t/hint-self-created-scan-configs-copy-of-empty-scan-config-showing-no-results/331)
 

--- a/src/faq.md
+++ b/src/faq.md
@@ -118,6 +118,7 @@ Some common issues if scans doesn't return any results are:
 
    - [Greenbone Enterprise Appliance documentation - Hosts not found](https://docs.greenbone.net/GSM-Manual/gos-22.04/en/scanning.html#hosts-not-found)
    - [Greenbone Enterprise Appliance documentation - Creating a target](https://docs.greenbone.net/GSM-Manual/gos-22.04/en/scanning.html#creating-a-target)
+   - [Greenbone Enterprise Appliance documentation - Alive Test](https://docs.greenbone.net/GSM-Manual/gos-22.04/en/scanning.html#alive-test)
 
 2. You're using a custom scan configuration which doesn't include the following
    two VTs from the **Port scanners** family.


### PR DESCRIPTION
## What
Some minor follow-up updates to #256 including:
- Fix formatting by using bullet points
- Fix outdated GOS 4.x link
- Additional GSM Manual link for Alive Test info
- Update SecInfo links

Some of these changes could be also applied to https://forum.greenbone.net/t/hint-hosts-are-not-scanned-not-shown-as-alive/332 but i'm lacking moderation permission to do so.

## Why

The reason to use bullet points can be seen in the screenshot below. The have been rendered one after another which makes them harder to read:

![Screenshot_2023-01-25_10-42-56](https://user-images.githubusercontent.com/34644702/214531951-9ba38bd1-d69e-46c2-83b0-156f97c0aae1.png)

Other changes have been done for consistency reasons or providing more info.

## References

N/A