### PR TITLE
Fix: Start mosquitto before ospd-openvas

### DIFF
--- a/src/22.4/source-build/systemd.rst
+++ b/src/22.4/source-build/systemd.rst
@@ -11,8 +11,8 @@ Setting up Services for *Systemd*
   [Unit]
   Description=OSPd Wrapper for the OpenVAS Scanner (ospd-openvas)
   Documentation=man:ospd-openvas(8) man:openvas(8)
-  After=network.target networking.service redis-server@openvas.service
-  Wants=redis-server@openvas.service
+  After=network.target networking.service redis-server@openvas.service mosquitto.service
+  Wants=redis-server@openvas.service mosquitto.service
   ConditionKernelCommandLine=!recovery
 
   [Service]

--- a/src/22.4/source-build/systemd.rst
+++ b/src/22.4/source-build/systemd.rst
@@ -12,7 +12,7 @@ Setting up Services for *Systemd*
   Description=OSPd Wrapper for the OpenVAS Scanner (ospd-openvas)
   Documentation=man:ospd-openvas(8) man:openvas(8)
   After=network.target networking.service redis-server@openvas.service mosquitto.service
-  Wants=redis-server@openvas.service mosquitto.service
+  Wants=redis-server@openvas.service mosquitto.service notus-scanner.service
   ConditionKernelCommandLine=!recovery
 
   [Service]

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update gvmd systemd service file to start gvmd in foreground to avoid issues
   with systemd tracking the started processes
 * Use ospd-openvas 22.4.4
+* Update ospd-openvas.service file to depend on the mosquitto service
 
 ## 23.1.0 - 23-01-13
 * Fix installing ospd-openvas and notus-scanner on Debian 11

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -14,7 +14,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update gvmd systemd service file to start gvmd in foreground to avoid issues
   with systemd tracking the started processes
 * Use ospd-openvas 22.4.4
-* Update ospd-openvas.service file to depend on the mosquitto service
+* Update ospd-openvas.service file to depend on the mosquitto and notus-scanner
+  services
 
 ## 23.1.0 - 23-01-13
 * Fix installing ospd-openvas and notus-scanner on Debian 11


### PR DESCRIPTION
## What

Start mosquitto before ospd-openvas

## Why

ospd-openvas depends on mosquitto as a MQTT broker to work correctly. Without being able to communicate with mosquitto ospd-openvas raises errors in the log.