### PR TITLE
Change: Run all daemons in exec mode

### DIFF
--- a/src/22.4/source-build/index.rst
+++ b/src/22.4/source-build/index.rst
@@ -129,7 +129,7 @@ ospd-openvas
 .. code-block::
   :caption: Setting the ospd and ospd-openvas versions to use
 
-  export OSPD_OPENVAS_VERSION=22.4.4
+  export OSPD_OPENVAS_VERSION=22.4.5
 
 .. include:: /22.4/source-build/ospd-openvas/dependencies.rst
 .. include:: /common/source-build/ospd-openvas/download.rst

--- a/src/22.4/source-build/systemd.rst
+++ b/src/22.4/source-build/systemd.rst
@@ -16,13 +16,13 @@ Setting up Services for *Systemd*
   ConditionKernelCommandLine=!recovery
 
   [Service]
-  Type=forking
+  Type=exec
   User=gvm
   Group=gvm
   RuntimeDirectory=ospd
   RuntimeDirectoryMode=2775
   PIDFile=/run/ospd/ospd-openvas.pid
-  ExecStart=/usr/local/bin/ospd-openvas --unix-socket /run/ospd/ospd-openvas.sock --pid-file /run/ospd/ospd-openvas.pid --log-file /var/log/gvm/ospd-openvas.log --lock-file-dir /var/lib/openvas --socket-mode 0o770 --mqtt-broker-address localhost --mqtt-broker-port 1883 --notus-feed-dir /var/lib/notus/advisories
+  ExecStart=/usr/local/bin/ospd-openvas --foreground --unix-socket /run/ospd/ospd-openvas.sock --pid-file /run/ospd/ospd-openvas.pid --log-file /var/log/gvm/ospd-openvas.log --lock-file-dir /var/lib/openvas --socket-mode 0o770 --mqtt-broker-address localhost --mqtt-broker-port 1883 --notus-feed-dir /var/lib/notus/advisories
   SuccessExitStatus=SIGKILL
   Restart=always
   RestartSec=60
@@ -48,12 +48,12 @@ Setting up Services for *Systemd*
   ConditionKernelCommandLine=!recovery
 
   [Service]
-  Type=forking
+  Type=exec
   User=gvm
   RuntimeDirectory=notus-scanner
   RuntimeDirectoryMode=2775
   PIDFile=/run/notus-scanner/notus-scanner.pid
-  ExecStart=/usr/local/bin/notus-scanner --products-directory /var/lib/notus/products --log-file /var/log/gvm/notus-scanner.log
+  ExecStart=/usr/local/bin/notus-scanner --foreground --products-directory /var/lib/notus/products --log-file /var/log/gvm/notus-scanner.log
   SuccessExitStatus=SIGKILL
   Restart=always
   RestartSec=60

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -11,8 +11,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Remove docs for 21.04 because it is end-of-life and wont get any updates
   anymore.
 * Extend FAQ for no results after finished scan
-* Update gvmd systemd service file to start gvmd in foreground to avoid issues
-  with systemd tracking the started processes
+* Update systemd service files to start the daemons in foreground to avoid
+  issues with systemd tracking the started processes
 * Use ospd-openvas 22.4.4
 * Update ospd-openvas.service file to depend on the mosquitto and notus-scanner
   services

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -13,7 +13,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Extend FAQ for no results after finished scan
 * Update systemd service files to start the daemons in foreground to avoid
   issues with systemd tracking the started processes
-* Use ospd-openvas 22.4.4
+* Use ospd-openvas 22.4.5
 * Update ospd-openvas.service file to depend on the mosquitto and notus-scanner
   services
 


### PR DESCRIPTION
## What

Run all daemons in exec mode

## Why

It seems the forking mode causes issues with systemd for users very often. Therefore run our daemons in foreground and use the systemd exec mode instead.

