### PR TITLE
Fix: Add missing ospd-openvas dependency for gnupg

### DIFF
--- a/src/22.4/source-build/ospd-openvas/dependencies.rst
+++ b/src/22.4/source-build/ospd-openvas/dependencies.rst
@@ -15,6 +15,7 @@
        python3-defusedxml \
        python3-paramiko \
        python3-redis \
+       python3-gnupg \
        python3-paho-mqtt
 
   .. tab:: Ubuntu
@@ -34,6 +35,7 @@
        python3-defusedxml \
        python3-paramiko \
        python3-redis \
+       python3-gnupg \
        python3-paho-mqtt
 
   .. tab:: Fedora
@@ -53,6 +55,7 @@
        python3-defusedxml \
        python3-paramiko \
        python3-redis \
+       python3-gnupg \
        python3-paho-mqtt
 
   .. tab:: CentOS
@@ -71,5 +74,6 @@
        python3-defusedxml \
        python3-paramiko \
        python3-redis \
+       python3-gnupg \
        python3-wheel
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ## Latest
 * Unify the directory layout of the documentation files
 * Use distinct installation directories for each component
+* Add missing python3-gnupg as dependency to ospd-openvas
 
 ## 23.1.1 - 23-01-31
 * Set `table_drive_lsc = yes` setting for openvas scanner to enable local


### PR DESCRIPTION
## What

Add missing ospd-openvas dependency for gnupg

## Why

ospd-openvas uses the python gnupg package for validating the feed data.