### PR TITLE
Improve python software installations

### DIFF
--- a/src/22.4/source-build/gvm-tools/dependencies.rst
+++ b/src/22.4/source-build/gvm-tools/dependencies.rst
@@ -6,6 +6,7 @@
      sudo apt install -y \
        python3 \
        python3-pip \
+       python3-venv \
        python3-setuptools \
        python3-packaging \
        python3-lxml \

--- a/src/22.4/source-build/gvm-tools/install.rst
+++ b/src/22.4/source-build/gvm-tools/install.rst
@@ -14,7 +14,10 @@ commands can be used:
 
   mkdir -p $INSTALL_DIR/gvm-tools
 
-  python3 -m pip install --root=$INSTALL_DIR/gvm-tools --no-warn-script-location gvm-tools
+  python3 -m venv $BUILD_DIR/gvm-tools-build-env --system-site-packages && \
+    source $BUILD_DIR/gvm-tools-build-env/bin/activate && \
+    python3 -m pip install --prefix $INSTALL_PREFIX --root=$INSTALL_DIR/gvm-tools --no-warn-script-location gvm-tools && \
+    deactivate
 
   sudo cp -rv $INSTALL_DIR/gvm-tools/* /
 

--- a/src/22.4/source-build/notus-scanner/build.rst
+++ b/src/22.4/source-build/notus-scanner/build.rst
@@ -1,25 +1,14 @@
-.. tabs::
-  .. tab:: Debian/CentOS
-    .. code-block::
-      :caption: Installing notus-scanner
+.. code-block::
+  :caption: Installing notus-scanner
 
-      cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
+  cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
 
-      mkdir -p $INSTALL_DIR/notus-scanner
+  mkdir -p $INSTALL_DIR/notus-scanner
 
-      python3 -m pip install . --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR/notus-scanner --no-warn-script-location
+  python3 -m venv $BUILD_DIR/notus-scanner-build-env --system-site-packages && \
+    source $BUILD_DIR/notus-scanner-build-env/bin/activate && \
+    python3 -m pip install --prefix $INSTALL_PREFIX --root=$INSTALL_DIR/notus-scanner --no-warn-script-location . && \
+    deactivate
 
-      sudo cp -rv $INSTALL_DIR/notus-scanner/* /
-
-  .. tab:: Ubuntu/Fedora
-    .. code-block::
-      :caption: Installing notus-scanner
-
-      cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
-
-      mkdir -p $INSTALL_DIR/notus-scanner
-
-      python3 -m pip install . --root=$INSTALL_DIR/notus-scanner --no-warn-script-location
-
-      sudo cp -rv $INSTALL_DIR/notus-scanner/* /
+  sudo cp -rv $INSTALL_DIR/notus-scanner/* /
 

--- a/src/22.4/source-build/notus-scanner/dependencies.rst
+++ b/src/22.4/source-build/notus-scanner/dependencies.rst
@@ -6,6 +6,7 @@
      sudo apt install -y \
        python3 \
        python3-pip \
+       python3-venv \
        python3-setuptools \
        python3-paho-mqtt \
        python3-psutil \

--- a/src/22.4/source-build/ospd-openvas/build.rst
+++ b/src/22.4/source-build/ospd-openvas/build.rst
@@ -1,25 +1,13 @@
-.. tabs::
-  .. tab:: Debian/CentOS
-    .. code-block::
-      :caption: Installing ospd-openvas
+.. code-block::
+  :caption: Installing ospd-openvas
 
-      cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
+  cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
 
-      mkdir -p $INSTALL_DIR/ospd-openvas
+  mkdir -p $INSTALL_DIR/ospd-openvas
 
-      python3 -m pip install . --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR/ospd-openvas --no-warn-script-location
+  python3 -m venv $BUILD_DIR/ospd-openvas-build-env --system-site-packages && \
+    source $BUILD_DIR/ospd-openvas-build-env/bin/activate && \
+    python3 -m pip install --prefix $INSTALL_PREFIX --root=$INSTALL_DIR/ospd-openvas --no-warn-script-location . && \
+    deactivate
 
-      sudo cp -rv $INSTALL_DIR/ospd-openvas/* /
-
-  .. tab:: Ubuntu/Fedora
-    .. code-block::
-      :caption: Installing ospd-openvas
-
-      cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
-
-      mkdir -p $INSTALL_DIR/ospd-openvas
-
-      python3 -m pip install . --root=$INSTALL_DIR/ospd-openvas --no-warn-script-location
-
-      sudo cp -rv $INSTALL_DIR/ospd-openvas/* /
-
+  sudo cp -rv $INSTALL_DIR/ospd-openvas/* /

--- a/src/22.4/source-build/ospd-openvas/dependencies.rst
+++ b/src/22.4/source-build/ospd-openvas/dependencies.rst
@@ -6,6 +6,7 @@
      sudo apt install -y \
        python3 \
        python3-pip \
+       python3-venv \
        python3-setuptools \
        python3-packaging \
        python3-wrapt \
@@ -26,6 +27,7 @@
      sudo apt install -y \
        python3 \
        python3-pip \
+       python3-venv \
        python3-setuptools \
        python3-packaging \
        python3-wrapt \

--- a/src/22.4/source-build/prerequisites.rst
+++ b/src/22.4/source-build/prerequisites.rst
@@ -272,3 +272,17 @@ Greenbone Community Signing key as fully trusted.
 
   echo "8AE4BE429B60A59B311C2E739823FAA60ED1E580:6:" > /tmp/ownertrust.txt
   gpg --import-ownertrust < /tmp/ownertrust.txt
+
+
+Setup Python
+------------
+
+To allow loading the to be installed Python packages the installation path must
+be made available for your system wide installed Python version.
+
+.. code-block::
+  :caption: Add installation directory to Python's module path
+
+  export PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}');")
+
+  echo "$INSTALL_PREFIX/lib/python$PYTHON_VERSION/site-packages" | sudo tee /usr/lib/python3/dist-packages/greenbone.pth

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Unify the directory layout of the documentation files
 * Use distinct installation directories for each component
 * Add missing python3-gnupg as dependency to ospd-openvas
+* Try to circumvent the Python module installation issues by using virtual
+  environments
 
 ## 23.1.1 - 23-01-31
 * Set `table_drive_lsc = yes` setting for openvas scanner to enable local


### PR DESCRIPTION
## What

Improve python software installations

## Why

Installing with pip using `--prefix` and `--root` is an unreliable mess because distributions are patching the system Python. Therefore use a virtual environment which avoids the patches.


