### PR TITLE
Fix: Fix copy and paste for postgres setup

### DIFF
--- a/src/22.4/source-build/postgres.rst
+++ b/src/22.4/source-build/postgres.rst
@@ -41,21 +41,23 @@ If necessary the PostgreSQL database server needs to be started manually
      sudo postgresql-setup --initdb --unit postgresql
      sudo systemctl start postgresql
 
+For setting up the PostgreSQL database it is required to become the postgres
+user.
+
 .. code-block::
-  :caption: Setting up PostgreSQL user and database
+  :caption: Changing to the postgres user
 
   sudo -u postgres bash
+
+.. code-block::
+  :caption: Setting up PostgreSQL user and database for the Greenbone Community Edition
+
   createuser -DRS gvm
   createdb -O gvm gvmd
-  exit
 
 .. code-block::
   :caption: Setting up database permissions and extensions
 
-  sudo -u postgres bash
-  psql gvmd
-  create role dba with superuser noinherit;
-  grant dba to gvm;
+  psql gvmd -c "create role dba with superuser noinherit; grant dba to gvm;"
 
-  exit
   exit

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Try to circumvent the Python module installation issues by using virtual
   environments
 * Don't display copy button for GPG verification output
+* Fix PostgreSQL setup and make it possible to copy and paste the corresponding
+  commands again
 
 ## 23.1.1 - 23-01-31
 * Set `table_drive_lsc = yes` setting for openvas scanner to enable local


### PR DESCRIPTION


## What

Fix copy and paste for postgres setup

## Why

Copy and pasting the commands wasn't possible and resulted in a broken environment for the user. Therefore fix the postgres setup by allowing to copy and paste the commands again.

## References

Should be merged after #265