### PR TITLE
Change: Allow to disable copy and paste button for code highlight

### DIFF
--- a/src/22.4/source-build/verify.rst
+++ b/src/22.4/source-build/verify.rst
@@ -1,4 +1,5 @@
 .. code-block:: none
+  :class: no-copybutton
 
   gpg: Signature made Fri Apr 16 08:31:02 2021 UTC
   gpg:                using RSA key 9823FAA60ED1E580

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Unify the directory layout of the documentation files
 * Use distinct installation directories for each component
 * Add missing python3-gnupg as dependency to ospd-openvas
+* Don't display copy button for GPG verification output
 
 ## 23.1.1 - 23-01-31
 * Set `table_drive_lsc = yes` setting for openvas scanner to enable local

--- a/src/conf.py
+++ b/src/conf.py
@@ -137,3 +137,6 @@ suppress_warnings = ["myst.header"]
 # toward ranking.  https://github.com/wpilibsuite/sphinxext-opengraph
 ogp_site_url = "http://greenbone.github.io/docs/latest/"
 ogp_image = "https://greenbone.github.io/docs/latest/_images/greenbone-banner.png"
+
+
+copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"


### PR DESCRIPTION
## What

Allow to disable copy and paste button for code highlight

## Why

Don't display copy and paste for the gpg signature verification output.

## References

https://sphinx-copybutton.readthedocs.io/en/latest/use.html#remove-copybuttons-using-a-css-selector