### PR TITLE
Change: Update to new releases

### DIFF
--- a/src/22.4/source-build/index.rst
+++ b/src/22.4/source-build/index.rst
@@ -37,7 +37,7 @@ gvm-libs
 .. code-block::
   :caption: Setting the gvm-libs version to use
 
-  export GVM_LIBS_VERSION=22.4.2
+  export GVM_LIBS_VERSION=22.4.3
 
 .. include:: /22.4/source-build/gvm-libs/dependencies.rst
 .. include:: /22.4/source-build/gvm-libs/download.rst
@@ -129,7 +129,7 @@ ospd-openvas
 .. code-block::
   :caption: Setting the ospd and ospd-openvas versions to use
 
-  export OSPD_OPENVAS_VERSION=22.4.5
+  export OSPD_OPENVAS_VERSION=22.4.6
 
 .. include:: /22.4/source-build/ospd-openvas/dependencies.rst
 .. include:: /22.4/source-build/ospd-openvas/download.rst
@@ -143,7 +143,7 @@ notus-scanner
 .. code-block::
   :caption: Setting the notus version to use
 
-  export NOTUS_VERSION=22.4.2
+  export NOTUS_VERSION=22.4.3
 
 .. include:: /22.4/source-build/notus-scanner/dependencies.rst
 .. include:: /22.4/source-build/notus-scanner/download.rst

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Fix PostgreSQL setup and make it possible to copy and paste the corresponding
   commands again
 * Use new `greenbone-feed-sync` script for the feed data download
+* Use ospd-openvas 22.4.6, notus-scanner 22.4.3 and gvm-libs 22.4.3
 
 ## 23.1.1 - 23-01-31
 * Set `table_drive_lsc = yes` setting for openvas scanner to enable local


### PR DESCRIPTION
## What

Use new releases of ospd-openvas, notus-scanner and gvm-libs from today.

## Why

ospd-openvas and notus-scanner also log to their logging files if they are running in foreground now.


