### PR TITLE
Change: Use same dependencies for Ubuntu and Debian for scanners

### DIFF
--- a/src/22.4/source-build/notus-scanner/dependencies.rst
+++ b/src/22.4/source-build/notus-scanner/dependencies.rst
@@ -1,5 +1,5 @@
 .. tabs::
-  .. tab:: Debian
+  .. tab:: Debian/Ubuntu
    .. code-block::
      :caption: Required dependencies for notus-scanner
 
@@ -12,24 +12,10 @@
        python3-psutil \
        python3-gnupg
 
-  .. tab:: Ubuntu
-   .. code-block::
-     :caption: Required dependencies for notus-scanner
-
-     INSTALL_PREFIX=/usr
-     sudo apt install -y \
-       python3 \
-       python3-pip \
-       python3-setuptools \
-       python3-paho-mqtt \
-       python3-psutil \
-       python3-gnupg
-
   .. tab:: Fedora
    .. code-block::
      :caption: Required dependencies for notus-scanner
 
-     INSTALL_PREFIX=/usr
      sudo dnf install -y \
        python3 \
        python3-pip \

--- a/src/22.4/source-build/ospd-openvas/dependencies.rst
+++ b/src/22.4/source-build/ospd-openvas/dependencies.rst
@@ -1,29 +1,8 @@
 .. tabs::
-  .. tab:: Debian
+  .. tab:: Debian/Ubuntu
    .. code-block::
      :caption: Required dependencies for ospd-openvas
 
-     sudo apt install -y \
-       python3 \
-       python3-pip \
-       python3-venv \
-       python3-setuptools \
-       python3-packaging \
-       python3-wrapt \
-       python3-cffi \
-       python3-psutil \
-       python3-lxml \
-       python3-defusedxml \
-       python3-paramiko \
-       python3-redis \
-       python3-gnupg \
-       python3-paho-mqtt
-
-  .. tab:: Ubuntu
-   .. code-block::
-     :caption: Required dependencies for ospd-openvas
-
-     INSTALL_PREFIX=/usr
      sudo apt install -y \
        python3 \
        python3-pip \
@@ -44,7 +23,6 @@
    .. code-block::
      :caption: Required dependencies for ospd-openvas
 
-     INSTALL_PREFIX=/usr
      sudo dnf install -y \
        python3 \
        python3-pip \


### PR DESCRIPTION


## What

Use same dependencies for Ubuntu and Debian for scanners

Ubuntu and Debian need the same Python dependencies for notus-scanner and ospd-openvas. Therefore merge these tabs. Also remove settings the INSTALL_PREFIX unnecessarily.

## Why

Setting the INSTALL_PREFIX is just wrong here.

## References

https://forum.greenbone.net/t/install-prefix-change-not-reflected-in-systemd-scripts/14043