### PR TITLE
Change: Try to fix installation of Python based applications again

### DIFF
--- a/src/22.4/source-build/greenbone-feed-sync/dependencies.rst
+++ b/src/22.4/source-build/greenbone-feed-sync/dependencies.rst
@@ -5,8 +5,7 @@
 
      sudo apt install -y \
        python3 \
-       python3-pip \
-       python3-venv
+       python3-pip
 
   .. tab:: Fedora/CentOS
    .. code-block::

--- a/src/22.4/source-build/greenbone-feed-sync/install.rst
+++ b/src/22.4/source-build/greenbone-feed-sync/install.rst
@@ -4,14 +4,23 @@ Python installation tool *pip*.
 To install it system-wide for all users without running *pip* as root user, the
 following commands can be used:
 
-.. code-block::
-  :caption: Installing greenbone-feed-sync system-wide for all users
+.. tabs::
+  .. tab:: Debian/Fedora/CentOS
+    .. code-block::
+      :caption: Installing greenbone-feed-sync system-wide for all users
 
-  mkdir -p $INSTALL_DIR/greenbone-feed-sync
+      mkdir -p $INSTALL_DIR/greenbone-feed-sync
 
-  python3 -m venv $BUILD_DIR/greenbone-feed-sync-build-env --system-site-packages && \
-    source $BUILD_DIR/greenbone-feed-sync-build-env/bin/activate && \
-    python3 -m pip install --prefix $INSTALL_PREFIX --root=$INSTALL_DIR/greenbone-feed-sync --no-warn-script-location greenbone-feed-sync && \
-    deactivate
+      python3 -m pip install --prefix $INSTALL_PREFIX --root=$INSTALL_DIR/greenbone-feed-sync --no-warn-script-location greenbone-feed-sync
 
-  sudo cp -rv $INSTALL_DIR/greenbone-feed-sync/* /
+      sudo cp -rv $INSTALL_DIR/greenbone-feed-sync/* /
+
+  .. tab:: Ubuntu
+    .. code-block::
+      :caption: Installing greenbone-feed-sync system-wide for all users
+
+      mkdir -p $INSTALL_DIR/greenbone-feed-sync
+
+      python3 -m pip install --root=$INSTALL_DIR/greenbone-feed-sync --no-warn-script-location greenbone-feed-sync
+
+      sudo cp -rv $INSTALL_DIR/greenbone-feed-sync/* /

--- a/src/22.4/source-build/gvm-tools/install.rst
+++ b/src/22.4/source-build/gvm-tools/install.rst
@@ -9,15 +9,24 @@ standard Python installation tool *pip*.
 To install it system-wide without running *pip* as root user, the following
 commands can be used:
 
-.. code-block::
-  :caption: Installing gvm-tools system-wide
+.. tabs::
+  .. tab:: Debian/Fedora/CentOS
+    .. code-block::
+      :caption: Installing gvm-tools system-wide
 
-  mkdir -p $INSTALL_DIR/gvm-tools
+      mkdir -p $INSTALL_DIR/gvm-tools
 
-  python3 -m venv $BUILD_DIR/gvm-tools-build-env --system-site-packages && \
-    source $BUILD_DIR/gvm-tools-build-env/bin/activate && \
-    python3 -m pip install --prefix $INSTALL_PREFIX --root=$INSTALL_DIR/gvm-tools --no-warn-script-location gvm-tools && \
-    deactivate
+      python3 -m pip install --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR/gvm-tools --no-warn-script-location gvm-tools
 
-  sudo cp -rv $INSTALL_DIR/gvm-tools/* /
+      sudo cp -rv $INSTALL_DIR/gvm-tools/* /
 
+.. tabs::
+  .. tab:: Ubuntu
+    .. code-block::
+      :caption: Installing gvm-tools system-wide
+
+      mkdir -p $INSTALL_DIR/gvm-tools
+
+      python3 -m pip install --root=$INSTALL_DIR/gvm-tools --no-warn-script-location gvm-tools
+
+      sudo cp -rv $INSTALL_DIR/gvm-tools/* /

--- a/src/22.4/source-build/notus-scanner/build.rst
+++ b/src/22.4/source-build/notus-scanner/build.rst
@@ -1,14 +1,24 @@
-.. code-block::
-  :caption: Installing notus-scanner
+.. tabs::
+  .. tab:: Debian/Fedora/CentOS
+    .. code-block::
+      :caption: Installing notus-scanner
 
-  cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
+      cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
 
-  mkdir -p $INSTALL_DIR/notus-scanner
+      mkdir -p $INSTALL_DIR/notus-scanner
 
-  python3 -m venv $BUILD_DIR/notus-scanner-build-env --system-site-packages && \
-    source $BUILD_DIR/notus-scanner-build-env/bin/activate && \
-    python3 -m pip install --prefix $INSTALL_PREFIX --root=$INSTALL_DIR/notus-scanner --no-warn-script-location . && \
-    deactivate
+      python3 -m pip install --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR/notus-scanner --no-warn-script-location .
 
-  sudo cp -rv $INSTALL_DIR/notus-scanner/* /
+      sudo cp -rv $INSTALL_DIR/notus-scanner/* /
 
+  .. tab:: Ubuntu
+    .. code-block::
+      :caption: Installing notus-scanner
+
+      cd $SOURCE_DIR/notus-scanner-$NOTUS_VERSION
+
+      mkdir -p $INSTALL_DIR/notus-scanner
+
+      python3 -m pip install --root=$INSTALL_DIR/notus-scanner --no-warn-script-location .
+
+      sudo cp -rv $INSTALL_DIR/notus-scanner/* /

--- a/src/22.4/source-build/notus-scanner/dependencies.rst
+++ b/src/22.4/source-build/notus-scanner/dependencies.rst
@@ -6,7 +6,6 @@
      sudo apt install -y \
        python3 \
        python3-pip \
-       python3-venv \
        python3-setuptools \
        python3-paho-mqtt \
        python3-psutil \

--- a/src/22.4/source-build/ospd-openvas/build.rst
+++ b/src/22.4/source-build/ospd-openvas/build.rst
@@ -1,13 +1,24 @@
-.. code-block::
-  :caption: Installing ospd-openvas
+.. tabs::
+  .. tab:: Debian/Fedora/CentOS
+    .. code-block::
+      :caption: Installing ospd-openvas
 
-  cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
+      cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
 
-  mkdir -p $INSTALL_DIR/ospd-openvas
+      mkdir -p $INSTALL_DIR/ospd-openvas
 
-  python3 -m venv $BUILD_DIR/ospd-openvas-build-env --system-site-packages && \
-    source $BUILD_DIR/ospd-openvas-build-env/bin/activate && \
-    python3 -m pip install --prefix $INSTALL_PREFIX --root=$INSTALL_DIR/ospd-openvas --no-warn-script-location . && \
-    deactivate
+      python3 -m pip install --prefix=$INSTALL_PREFIX --root=$INSTALL_DIR/ospd-openvas --no-warn-script-location .
 
-  sudo cp -rv $INSTALL_DIR/ospd-openvas/* /
+      sudo cp -rv $INSTALL_DIR/ospd-openvas/* /
+
+  .. tab:: Ubuntu
+    .. code-block::
+      :caption: Installing ospd-openvas
+
+      cd $SOURCE_DIR/ospd-openvas-$OSPD_OPENVAS_VERSION
+
+      mkdir -p $INSTALL_DIR/ospd-openvas
+
+      python3 -m pip install --root=$INSTALL_DIR/ospd-openvas --no-warn-script-location .
+
+      sudo cp -rv $INSTALL_DIR/ospd-openvas/* /

--- a/src/22.4/source-build/ospd-openvas/dependencies.rst
+++ b/src/22.4/source-build/ospd-openvas/dependencies.rst
@@ -6,7 +6,6 @@
      sudo apt install -y \
        python3 \
        python3-pip \
-       python3-venv \
        python3-setuptools \
        python3-packaging \
        python3-wrapt \

--- a/src/22.4/source-build/prerequisites.rst
+++ b/src/22.4/source-build/prerequisites.rst
@@ -272,17 +272,3 @@ Greenbone Community Signing key as fully trusted.
 
   echo "8AE4BE429B60A59B311C2E739823FAA60ED1E580:6:" > /tmp/ownertrust.txt
   gpg --import-ownertrust < /tmp/ownertrust.txt
-
-
-Setup Python
-------------
-
-To allow loading the to be installed Python packages the installation path must
-be made available for your system wide installed Python version.
-
-.. code-block::
-  :caption: Add installation directory to Python's module path
-
-  export PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}');")
-
-  echo "$INSTALL_PREFIX/lib/python$PYTHON_VERSION/site-packages" | sudo tee /usr/lib/python3/dist-packages/greenbone.pth

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -9,14 +9,16 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Unify the directory layout of the documentation files
 * Use distinct installation directories for each component
 * Add missing python3-gnupg as dependency to ospd-openvas
-* Try to circumvent the Python module installation issues by using virtual
-  environments
 * Don't display copy button for GPG verification output
 * Fix PostgreSQL setup and make it possible to copy and paste the corresponding
   commands again
 * Use new `greenbone-feed-sync` script for the feed data download
 * Use ospd-openvas 22.4.6, notus-scanner 22.4.4 and gvm-libs 22.4.4
 * Remove 21.4 from the architecture docs
+* Try to fix installation of `ospd-openvas`, `notus-scanner`, `gvm-tools` and
+  `greenbone-feed-sync` again due to issues with distributions patching Python
+  installation paths. See [discuss.python.org](https://discuss.python.org/t/linux-distro-patches-to-sysconfig-are-changing-pip-install-prefix-outside-virtual-environments/18240)
+  for more details.
 
 ## 23.1.1 - 23-01-31
 * Set `table_drive_lsc = yes` setting for openvas scanner to enable local


### PR DESCRIPTION

## What

Try to fix installation of Python based applications again

Revert using the virtual environments for installing our Python based applications because that used an absolute to the Python executable of the venv in all installed scripts which of course doesn't work at the end.

## Why

Using venv doesn't work.

## References

https://forum.greenbone.net/t/build-from-source-url-not-found/14081/4
https://discuss.python.org/t/linux-distro-patches-to-sysconfig-are-changing-pip-install-prefix-outside-virtual-environments/18240