### PR TITLE
Change: Switch setting install prefix and path sections

### DIFF
--- a/src/22.4/source-build/prerequisites.rst
+++ b/src/22.4/source-build/prerequisites.rst
@@ -42,19 +42,6 @@ To make the group change effective either logout and login again or use
 
   su $USER
 
-Setting the PATH
-----------------
-
-On Debian systems the locations :file:`/sbin`, :file:`/usr/sbin` and
-:file:`/usr/local/sbin` are not in the :envvar:`PATH` of normal users. To run
-*gvmd* which is located in :file:`/usr/local/sbin` the :envvar:`PATH`
-environment variable should be adjusted.
-
-.. code-block::
-  :caption: Adjusting PATH for running gvmd
-
-  export PATH=$PATH:/usr/local/sbin
-
 Choosing an Install Prefix
 --------------------------
 
@@ -70,6 +57,19 @@ to be able to reference it later.
   :caption: Setting an install prefix environment variable
 
   export INSTALL_PREFIX=/usr/local
+
+Setting the PATH
+----------------
+
+On Debian systems the locations :file:`/sbin`, :file:`/usr/sbin` and
+:file:`/usr/local/sbin` are not in the :envvar:`PATH` of normal users. To run
+*gvmd* which is located in :file:`/usr/local/sbin` the :envvar:`PATH`
+environment variable should be adjusted.
+
+.. code-block::
+  :caption: Adjusting PATH for running gvmd
+
+  export PATH=$PATH:$INSTALL_PREFIX/sbin
 
 Creating a Source, Build and Install Directory
 ----------------------------------------------

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
   `greenbone-feed-sync` again due to issues with distributions patching Python
   installation paths. See [discuss.python.org](https://discuss.python.org/t/linux-distro-patches-to-sysconfig-are-changing-pip-install-prefix-outside-virtual-environments/18240)
   for more details.
+* Switch *Choosing an Install Prefix* and *Setting the PATH* section in source
+  build to allow using $INSTALL_PREFIX when setting the $PATH.
 
 ## 23.1.1 - 23-01-31
 * Set `table_drive_lsc = yes` setting for openvas scanner to enable local


### PR DESCRIPTION
## What

Switch setting install prefix and path sections

## Why

Switch *Choosing an Install Prefix* and *Setting the PATH* section in source build to allow using $INSTALL_PREFIX when setting the $PATH.