### PR TITLE
Change: Update to notus-scanner 22.4.5

### DIFF
--- a/src/22.4/source-build/index.rst
+++ b/src/22.4/source-build/index.rst
@@ -143,7 +143,7 @@ notus-scanner
 .. code-block::
   :caption: Setting the notus version to use
 
-  export NOTUS_VERSION=22.4.4
+  export NOTUS_VERSION=22.4.5
 
 .. include:: /22.4/source-build/notus-scanner/dependencies.rst
 .. include:: /22.4/source-build/notus-scanner/download.rst

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ## Latest
 * Fix tab title in *Setting up sudo for Scanning* section from Debian/CentOS to
   Debian/Ubuntu.
+* Update notus-scanner to 22.4.5
 
 ## 23.3.0
 * Unify the directory layout of the documentation files


### PR DESCRIPTION
## What

Update to notus-scanner 22.4.5

## Why

notus-scanner got a new release to fix RPM package comparisons with epochs.

## References

https://github.com/greenbone/notus-scanner/pull/453


