### PR TITLE
Added composite action SBOM SPDX to dependency graph

### DIFF
--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -1,0 +1,14 @@
+name: SBOM upload
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+jobs:
+  SBOM-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: 'SBOM upload'
+        uses: greenbone/actions/sbom-upload@v2


### PR DESCRIPTION
## What

Implementing SPDX to Dependency Graph Action.

## Why

Improve security posture via the Github Enterprise Advanced Security action to makes it easy to upload an SPDX 2.2 formatted SBOM to GitHub's dependency submission API.
This lets you quickly receive Dependabot alerts for package manifests which GitHub doesn't directly support like pnpm or Paket by using existing off-the-shelf SBOM generators.

## References

Related to Jira DEVOPS-648
More info [spdx-dependency-submission-action](https://github.com/marketplace/actions/spdx-dependency-submission-action) and [Exporting a software bill of materials for your repository](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/exporting-a-software-bill-of-materials-for-your-repository).


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tested in pipeline experiments
