### PR TITLE
Fix: Avoid permission errors when setting up postgres db

### DIFF
--- a/src/22.4/source-build/postgres.md
+++ b/src/22.4/source-build/postgres.md
@@ -56,6 +56,7 @@ sudo -u postgres bash
 ```{code-block}
 :caption: Setting up PostgreSQL user and database for the Greenbone Community Edition
 
+cd
 createuser -DRS gvm
 createdb -O gvm gvmd
 ```

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
   Debian/Ubuntu.
 * Update notus-scanner to 22.4.5
 * Change all documents to use markdown instead of rst
+* Change current working directory before setting up postgres database
 
 ## 23.3.0
 * Unify the directory layout of the documentation files


### PR DESCRIPTION
## What

Avoid permission errors when setting up postgres db

## Why

Depending on the default settings for creating a user the current working directory may not be executable and readable for the postgres user. When running the commands for setting up the postgres database in this home directory permission errors may be raised. To avoid that change into the home directory of the postgres user before setting up the database.
