### PR TITLE
Fixing some failed commands for CentOS source code install

### DIFF
--- a/src/22.4/source-build/greenbone-feed-sync/dependencies.md
+++ b/src/22.4/source-build/greenbone-feed-sync/dependencies.md
@@ -12,7 +12,7 @@
    .. code-block::
      :caption: Required dependencies for greenbone-feed-sync
 
-     dnf install -y \
+     sudo dnf install -y \
        python3 \
        python3-pip
 ```

--- a/src/22.4/source-build/gvm-tools/dependencies.md
+++ b/src/22.4/source-build/gvm-tools/dependencies.md
@@ -18,7 +18,7 @@
    .. code-block::
      :caption: Required dependencies for gvm-tools
 
-     dnf install -y \
+     sudo dnf install -y \
        python3 \
        python3-pip \
        python3-setuptools \

--- a/src/22.4/source-build/redis.md
+++ b/src/22.4/source-build/redis.md
@@ -20,16 +20,16 @@ the {term}`VT` information and scan results.
      sudo dnf install -y policycoreutils-python-utils
      sudo semanage fcontext -a -f a -t redis_var_run_t -r s0 '/var/run/redis-openvas(/.*)?'
 
-     sudo cat << EOF > /etc/tmpfiles.d/redis-openvas.conf
+     sudo sh -c 'cat << EOF > /etc/tmpfiles.d/redis-openvas.conf
      d       /var/lib/redis/openvas   0750 redis redis - -
      z       /var/lib/redis/openvas   0750 redis redis - -
      d       /run/redis-openvas       0750 redis redis - -
      z       /run/redis-openvas       0750 redis redis - -
-     EOF
+     EOF'
 
-     systemd-tmpfiles  --create
+     sudo systemd-tmpfiles  --create
 
-     sudo cat << EOF > /etc/systemd/system/redis-server@.service
+     sudo sh -c 'cat << EOF > /etc/systemd/system/redis-server@.service
      [Unit]
      Description=Redis persistent key-value database
      After=network.target
@@ -48,7 +48,7 @@ the {term}`VT` information and scan results.
 
      [Install]
      WantedBy=multi-user.target
-     EOF
+     EOF'
 ```
 
 After installing the Redis server package, a specific configuration for the


### PR DESCRIPTION
## What

Fixing missing `sudo` on two rpm install commands and also fixing `sudo` permission error on chained commands.

## Why

Some CentOS source code install commands fail due to permission errors because sudo is not passed to chained commands appropriately.

## References

None

## Checklist

- [ *] I tested these changes on CentOS stream 9 


