### PR TITLE
Fix spelling of 'pre-built'

### DIFF
--- a/src/22.4/container/introduction.md
+++ b/src/22.4/container/introduction.md
@@ -1,7 +1,7 @@
 ## Introduction
 
 This document provides a guide for running the {term}`Greenbone Community Edition`
-from pre-build container images using [Docker]. It consists of a distributed
+from pre-built container images using [Docker]. It consists of a distributed
 service {doc}`architecture </architecture>`, where each service is run in a
 dedicated container. The orchestration of these services is done via a [docker-compose]
 file.

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -85,7 +85,7 @@ Greenbone Community Edition
 
 Greenbone Community Containers
 
-  Container images that are pre-build on [GitHub](https://github.com/greenbone)
+  Container images that are pre-built on [GitHub](https://github.com/greenbone)
   and available via [dockerhub](https://hub.docker.com/u/greenbone). These
   images can be used to run the newest versions of the {term}`Greenbone Community Edition`
   without having to care about the operating system, compiler and build


### PR DESCRIPTION
Use *pre-built* as the container images are built in advance.



