### PR TITLE
Change: Update pg-gvm to 22.5.1 and gsad to 22.5.0 releases

### DIFF
--- a/src/22.4/source-build/gsad/version.md
+++ b/src/22.4/source-build/gsad/version.md
@@ -1,5 +1,0 @@
-```{code-block}
-:caption: Setting the GSAd version to use
-
-export GSAD_VERSION=$GVM_VERSION
-```

--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -83,7 +83,7 @@ Details about the optional dependencies can be found at
 ```{code-block}
 :caption: Setting the pg-gvm version to use
 
-export PG_GVM_VERSION=22.4.0
+export PG_GVM_VERSION=22.5.1
 ```
 
 ```{include} /22.4/source-build/pg-gvm/dependencies.md
@@ -110,7 +110,7 @@ The Greenbone Security Assistant (GSA) sources consist of two parts:
 ```
 
 ```{code-block}
-:caption: Setting the gvmd version to use
+:caption: Setting the GSA version to use
 
 export GSA_VERSION=$GVM_VERSION
 ```
@@ -126,7 +126,10 @@ export GSA_VERSION=$GVM_VERSION
 ```{include} /22.4/source-build/gsad/description.md
 ```
 
-```{include} /22.4/source-build/gsad/version.md
+```{code-block}
+:caption: Setting the GSAd version to use
+
+export GSAD_VERSION=22.5.0
 ```
 
 ```{include} /22.4/source-build/gsad/dependencies.md

--- a/src/22.4/source-build/pg-gvm/build.md
+++ b/src/22.4/source-build/pg-gvm/build.md
@@ -1,26 +1,13 @@
 ```{eval-rst}
 .. tabs::
-  .. tab:: Debian
+  .. tab:: Debian/Ubuntu
     .. code-block::
       :caption: Building pg-gvm
 
       mkdir -p $BUILD_DIR/pg-gvm && cd $BUILD_DIR/pg-gvm
 
       cmake $SOURCE_DIR/pg-gvm-$PG_GVM_VERSION \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DPostgreSQL_ADDITIONAL_VERSIONS=15
-
-      make -j$(nproc)
-
-  .. tab:: Ubuntu
-    .. code-block::
-      :caption: Building pg-gvm
-
-      mkdir -p $BUILD_DIR/pg-gvm && cd $BUILD_DIR/pg-gvm
-
-      cmake $SOURCE_DIR/pg-gvm-$PG_GVM_VERSION \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DPostgreSQL_TYPE_INCLUDE_DIR=/usr/include/postgresql
+        -DCMAKE_BUILD_TYPE=Release
 
       make -j$(nproc)
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## Latest
+* Update to use Debian 12 (bookworm)
 * Install GSA from pre-built distributable files
 * Update openvas-smb to 22.5.3
 * Update gvmd to 22.5.0
+* Update pg-gvm to 22.5.1
+* Update gsad to 22.5.0
 * Removed adjusting permissions for greenbone-feed-sync script unnecessarily
 * Enable services only after first feed sync
-* Update to use Debian 12 (bookworm)
 
 ## 23.6.1 – 23-06-15
 * Update gvm-libs to 22.6.3


### PR DESCRIPTION
## What

Update pg-gvm to 22.5.1 and gsad to 22.5.0 release

## Why

Use newest releases of pg-gvm and gsad. pg-gvm 22.5.1 will find postgres 14 and 15 too.
