### PR TITLE
Change: Update gvmd, gsa and openvas-scanner versions

### DIFF
--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -48,7 +48,7 @@ Afterwards, gvm-libs can be build and installed.
 ```{code-block}
 :caption: Setting the gvmd version to use
 
-export GVMD_VERSION=22.5.4
+export GVMD_VERSION=22.6.0
 ```
 
 ```{include} /22.4/source-build/gvmd/dependencies.md
@@ -100,7 +100,7 @@ The Greenbone Security Assistant (GSA) sources consist of two parts:
 ```{code-block}
 :caption: Setting the GSA version to use
 
-export GSA_VERSION=22.5.0
+export GSA_VERSION=22.5.1
 ```
 
 ```{include} /22.4/source-build/gsa/download.md
@@ -142,7 +142,7 @@ export GSAD_VERSION=22.5.1
 ```{code-block}
 :caption: Setting the openvas-scanner version to use
 
-export OPENVAS_SCANNER_VERSION=22.7.2
+export OPENVAS_SCANNER_VERSION=22.7.3
 ```
 
 ```{include} /22.4/source-build/openvas-scanner/dependencies.md

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -6,11 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## Latest
-* Update gvmd to 22.5.4
+* Update gvmd to 22.6.0
 * Update gsad to 22.5.1
-* Update GSA to 22.5.0
+* Update GSA to 22.5.1
 * Update ospd-openvas to 22.5.3
+* Update openvas-scanner to 22.7.3
 * Remove *Setting the Version* chapter
+* Document how to configure a mail transport agent (MTA) for the community
+  containers
 
 ## 23.6.2 – 23-06-27
 * Update to use Debian 12 (bookworm)


### PR DESCRIPTION


## What
 Update gvmd, gsa and openvas-scanner versions

## Why

Use the newest releases in the source build guide.