### PR TITLE
Change: Install latest docker-compose

### DIFF
--- a/src/22.4/container/prerequisites.md
+++ b/src/22.4/container/prerequisites.md
@@ -75,25 +75,16 @@ the services of the Greenbone Community Edition. The description of the service
 orchestration is done by using [compose files](https://docs.docker.com/compose/compose-file/).
 A compose file for the Greenbone Community Edition is provided later on.
 
-`````{tabs}
-````{tab} Debian/Ubuntu
+
 ```{code-block} shell
 ---
-caption: Install docker-compose Debian/Ubuntu package
+caption: Install docker-compose
 ---
-sudo apt install docker-compose
+curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -o docker-compose
+chmod +x docker-compose
+sudo mv docker-compose /usr/local/bin
 ```
-````
-````{tab} Fedora/CentOS
-```{code-block} shell
----
-caption: Install docker-compose Fedora/CentOS package
----
-sudo dnf install python3-pip
-python3 -m pip install --user docker-compose
-```
-````
-`````
+
 ### Setup
 
 To allow the current user to run {command}`docker` and therefore start the


### PR DESCRIPTION
## What
This PR changes the install guide for `docker-compose` to use the latest release instead of the Debian / Ubuntu package or the one from PyPi.

## Why
`The final Compose V1 release, version 1.29.2, was May 10, 2021. These packages haven't received any security updates since then. Use at your own risk.` (from https://docs.docker.com/compose/migrate/).
Both the Debian / Ubuntu package and the PyPi package contain Compose v1, which we shouldn't recommend using any more (Note: Compose v2 will be available for the upcoming Ubuntu 23.10 as `docker-compose-v2`).

Possible approaches:
1. Use Compose v2 as a plugin of Docker by installing `docker-compose-plugin`. This requires to use use the official Docker repo and not the Debian / Ubuntu repo.
2. Keep Compose as a standalone binary and use v2

Personally, I'd be in favor of following approach 1 and using the official Docker repos, like we're already recommending for CentOS / Fedora. This would ease the setup for users, because they can just install everything in one single command, but also introduces a dependence on Docker. Switching from Compose standalone to the Compose plugin however would require to change all occurrences of `docker-compose` to `docker compose`.
To not go beyond the scope of this PR and risk redundant work, I therefore opted for approach 2 (for now). If e.g. @bjoernricks is also for approach 1, I'm happy to adjust this PR.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


