### PR TITLE
Use official Docker repository and install Compose v2

### DIFF
--- a/src/22.4/container/admin-user.md
+++ b/src/22.4/container/admin-user.md
@@ -12,6 +12,6 @@ generated password, the following command can be used:
 ---
 caption: Updating password of administrator user
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     exec -u gvmd gvmd gvmd --user=admin --new-password=<password>
 ```

--- a/src/22.4/container/manual-feed-sync.md
+++ b/src/22.4/container/manual-feed-sync.md
@@ -22,7 +22,7 @@ available for 22.4.
 ---
 caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while.
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     run --rm ospd-openvas greenbone-nvt-sync
 ```
 
@@ -34,7 +34,7 @@ docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-editio
 ---
 caption: Syncing SCAP data processed by gvmd, this will take a while
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     run --rm gvmd greenbone-feed-sync --type SCAP
 ```
 
@@ -45,7 +45,7 @@ and [CERT-Bund](https://cert-bund.de/) agencies.
 ---
 caption: Syncing CERT data processed by gvmd
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     run --rm gvmd greenbone-feed-sync --type CERT
 ```
 
@@ -56,6 +56,6 @@ and report formats.
 ---
 caption: Syncing data objects processed by gvmd
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     run --rm gvmd greenbone-feed-sync --type GVMD_DATA
 ```

--- a/src/22.4/container/prerequisites.md
+++ b/src/22.4/container/prerequisites.md
@@ -41,9 +41,28 @@ installed by running (taken from the Docker Engine [install guide](https://docs.
 ````{tab} Debian/Ubuntu
 ```{code-block} shell
 ---
-caption: Install docker Debian/Ubuntu package
+caption: Uninstall conflicting Debian/Ubuntu packages
 ---
-sudo apt install docker.io
+for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt remove $pkg; done
+```
+```{code-block} shell
+---
+caption: Set up the Docker repository
+---
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+```
+```{code-block} shell
+---
+caption: Install Docker Debian/Ubuntu packages
+---
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 ```
 ````
 ````{tab} Fedora

--- a/src/22.4/container/prerequisites.md
+++ b/src/22.4/container/prerequisites.md
@@ -38,10 +38,10 @@ sudo dnf install ca-certificates curl gnupg
 installed by running (taken from the Docker Engine [install guide](https://docs.docker.com/engine/install/)):
 
 `````{tabs}
-````{tab} Debian/Ubuntu
+````{tab} Debian
 ```{code-block} shell
 ---
-caption: Uninstall conflicting Debian/Ubuntu packages
+caption: Uninstall conflicting Debian packages
 ---
 for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt remove $pkg; done
 ```
@@ -60,7 +60,34 @@ sudo apt update
 ```
 ```{code-block} shell
 ---
-caption: Install Docker Debian/Ubuntu packages
+caption: Install Docker Debian packages
+---
+sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+```
+````
+````{tab} Ubuntu
+```{code-block} shell
+---
+caption: Uninstall conflicting Ubuntu packages
+---
+for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt remove $pkg; done
+```
+```{code-block} shell
+---
+caption: Set up the Docker repository
+---
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+```
+```{code-block} shell
+---
+caption: Install Docker Ubuntu packages
 ---
 sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 ```

--- a/src/22.4/container/prerequisites.md
+++ b/src/22.4/container/prerequisites.md
@@ -8,26 +8,26 @@ output of a previous command.
 The command {command}`sudo` is used for executing commands that require privileged
 access on the system.
 
-### Install curl
+### Install dependencies
 
-[curl](https://curl.se/) is required for downloading files from this guide.
+There are a few dependencies required for the following steps like [curl](https://curl.se/), which is required for downloading files from this guide.
 
 
 `````{tabs}
 ````{tab} Debian/Ubuntu
 ```{code-block} shell
 ---
-caption: Install curl Debian package
+caption: Install ca-certificates, curl and gnupg Debian/Ubuntu packages
 ---
-sudo apt install curl
+sudo apt install ca-certificates curl gnupg
 ```
 ````
 ````{tab} Fedora/CentOS
 ```{code-block} shell
 ---
-caption: Install curl Fedora/CentOS package
+caption: Install ca-certificates, curl and gnupg Fedora/CentOS packages
 ---
-sudo dnf install curl
+sudo dnf install ca-certificates curl gnupg
 ```
 ````
 `````

--- a/src/22.4/container/prerequisites.md
+++ b/src/22.4/container/prerequisites.md
@@ -35,7 +35,7 @@ sudo dnf install ca-certificates curl gnupg
 ### Installing Docker
 
 [docker] is required for running the services within containers. Docker can be
-installed by running (taken from the Docker Engine [install guide](https://docs.docker.com/engine/install/)):
+installed by running the following commands (taken from the Docker Engine [install guide](https://docs.docker.com/engine/install/)):
 
 `````{tabs}
 ````{tab} Debian

--- a/src/22.4/container/prerequisites.md
+++ b/src/22.4/container/prerequisites.md
@@ -68,11 +68,23 @@ sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 ````{tab} Fedora
 ```{code-block} shell
 ---
+caption: Uninstall conflicting Fedora packages
+---
+sudo dnf remove docker docker-client docker-client-latest docker-common docker-latest docker-latest-logrotate docker-logrotate docker-selinux docker-engine-selinux docker-engine
+```
+```{code-block} shell
+---
 caption: Install docker Fedora package
 ---
 sudo dnf -y install dnf-plugins-core
 sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
-sudo dnf install -y docker-ce docker-ce-cli containerd.io
+sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+```
+```{code-block} shell
+---
+caption: Start Docker
+---
+sudo systemctl start docker
 ```
 ````
 ````{tab} CentOS

--- a/src/22.4/container/prerequisites.md
+++ b/src/22.4/container/prerequisites.md
@@ -35,7 +35,7 @@ sudo dnf install ca-certificates curl gnupg
 ### Installing Docker
 
 [docker] is required for running the services within containers. Docker can be
-installed by running:
+installed by running (taken from the Docker Engine [install guide](https://docs.docker.com/engine/install/)):
 
 `````{tabs}
 ````{tab} Debian/Ubuntu

--- a/src/22.4/container/prerequisites.md
+++ b/src/22.4/container/prerequisites.md
@@ -90,41 +90,27 @@ sudo systemctl start docker
 ````{tab} CentOS
 ```{code-block} shell
 ---
-caption: Install docker Fedora package
+caption: Uninstall conflicting CentOS packages
+---
+sudo dnf remove docker docker-client docker-client-latest docker-common docker-latest docker-latest-logrotate docker-logrotate docker-selinux docker-engine-selinux docker-engine
+```
+```{code-block} shell
+---
+caption: Install Docker CentOS package
 ---
 sudo dnf -y install dnf-plugins-core
 sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-sudo dnf install -y docker-ce docker-ce-cli containerd.io
+sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+```
+```{code-block} shell
+---
+caption: Start Docker
+---
+sudo systemctl start docker
 ```
 ````
 `````
 
-### Installing docker-compose
-
-[docker-compose] version 1.29.0 or newer is required for starting and connecting
-the services of the Greenbone Community Edition. The description of the service
-orchestration is done by using [compose files](https://docs.docker.com/compose/compose-file/).
-A compose file for the Greenbone Community Edition is provided later on.
-
-`````{tabs}
-````{tab} Debian/Ubuntu
-```{code-block} shell
----
-caption: Install docker-compose Debian/Ubuntu package
----
-sudo apt install docker-compose
-```
-````
-````{tab} Fedora/CentOS
-```{code-block} shell
----
-caption: Install docker-compose Fedora/CentOS package
----
-sudo dnf install python3-pip
-python3 -m pip install --user docker-compose
-```
-````
-`````
 ### Setup
 
 To allow the current user to run {command}`docker` and therefore start the

--- a/src/22.4/container/starting.md
+++ b/src/22.4/container/starting.md
@@ -7,14 +7,14 @@ and the containers can be started in the background.
 ---
 caption: Downloading the Greenbone Community Containers
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition pull
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition pull
 ```
 
 ```{code-block} shell
 ---
 caption: Starting the Greenbone Community Containers
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d
 ```
 
 To get a continuous stream of the log output of all services, run the following
@@ -24,7 +24,7 @@ command:
 ---
 caption: Show log messages of all services from the running containers
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition logs -f
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition logs -f
 ```
 
 The log stream can be stopped by pressing {kbd}`Ctrl-C`.

--- a/src/22.4/container/troubleshooting.md
+++ b/src/22.4/container/troubleshooting.md
@@ -10,7 +10,7 @@ scanner.
 ---
 caption: Restart the scanner to ensure that new {term}`VTs<VT>` are loaded
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     restart ospd-openvas
 ```
 
@@ -22,7 +22,7 @@ If port lists, scan configurations, or report formats are missing on the web int
 ---
 caption: Force reload of report formats, scan configs and port lists
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     exec -u gvmd gvmd gvmd --rebuild-gvmd-data=all
 ```
 
@@ -49,7 +49,7 @@ restart the corresponding container with:
 ---
 caption: Restart the ospd-openvas scanner
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     restart ospd-openvas
 ```
 
@@ -59,7 +59,7 @@ If you still get errors, you need to take a look at the `ospd-openvas` logs.
 ---
 caption: Show log message of the ospd-openvas scanner
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     log -f ospd-openvas
 ```
 
@@ -84,7 +84,7 @@ had some issues accessing the PostgreSQL database.
 ---
 caption: Restart {term}`gvmd`
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     restart gvmd
 ```
 
@@ -100,9 +100,9 @@ The volume can be removed safely because it gets re-created on the next startup.
 ---
 caption: Re-create redis server socket volume
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     rm -s -f redis-server ospd-openvas
 docker volume rm greenbone-community-edition_redis_socket_vol
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     up -d
 ```

--- a/src/22.4/container/workflows.md
+++ b/src/22.4/container/workflows.md
@@ -10,14 +10,14 @@ be done with:
 ---
 caption: Downloading the Greenbone Community Containers
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition pull
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition pull
 ```
 
 ```{code-block} shell
 ---
 caption: Starting the Greenbone Community Containers
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d
 ```
 
 ## Performing a Feed Synchronization
@@ -36,7 +36,7 @@ Both steps may take a while, from several minutes up to hours, especially for th
 initial synchronization. Only if both steps are finished, the synchronized data
 is up-to-date and can be used.
 
-The first step is done via the {command}`docker-compose pull`. The second step is
+The first step is done via the {command}`docker compose pull`. The second step is
 done automatically when the daemons are running.
 
 ### Downloading the Feed Changes
@@ -52,7 +52,7 @@ To download the latest feed data container images run
 ---
 caption: Downloading the Greenbone Community Edition feed data containers
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition pull notus-data vulnerability-tests scap-data dfn-cert-data cert-bund-data report-formats data-objects
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition pull notus-data vulnerability-tests scap-data dfn-cert-data cert-bund-data report-formats data-objects
 ```
 
 To copy the data from the images to the volumes run
@@ -61,7 +61,7 @@ To copy the data from the images to the volumes run
 ---
 caption: Starting the Greenbone Community feed data containers
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d notus-data vulnerability-tests scap-data dfn-cert-data cert-bund-data report-formats data-objects
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d notus-data vulnerability-tests scap-data dfn-cert-data cert-bund-data report-formats data-objects
 ```
 
 ### Loading the Feed Changes
@@ -205,7 +205,7 @@ by running:
 ---
 caption: Remove containers and volumes (all data)
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition down -v
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition down -v
 ```
 
 ##  Gaining a Terminal for a Container
@@ -220,7 +220,7 @@ To access a container with a bash shell as a root user, you can run:
 ---
 caption: Gain a Terminal for a Container
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition exec <container-name> /bin/bash
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition exec <container-name> /bin/bash
 ```
 
 Afterwards, you can execute standard bash commands within the running container.
@@ -235,7 +235,7 @@ can be started with:
 ---
 caption: Start container for gvm-tools CLI access
 ---
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition run --rm gvm-tools
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition run --rm gvm-tools
 ```
 
 Afterwards, a bash shell is provided and `gvm-cli`, `gvm-pyshell` or `gvm-script`
@@ -295,7 +295,7 @@ In the next step, the docker compose file must be changed as follows:
 After restarting the containers with
 
 ```bash
-docker-compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition up -d
 ```
 
 the Unix socket should be available at `/tmp/gvm/gvmd/gvmd.sock`. For example,

--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -32,7 +32,6 @@ RELEASE="22.4"
 
 installed curl
 installed docker
-installed docker-compose
 
 echo "Using Greenbone Community Containers $RELEASE"
 

--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -42,15 +42,15 @@ echo "Downloading docker-compose file..."
 curl -f -O https://greenbone.github.io/docs/latest/_static/docker-compose-$RELEASE.yml
 
 echo "Pulling Greenbone Community Containers $RELEASE"
-docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition pull
+docker compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition pull
 echo
 
 echo "Starting Greenbone Community Containers $RELEASE"
-docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition up -d
+docker compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition up -d
 echo
 
 read -s -p "Password for admin user: " password
-docker-compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition \
+docker compose -f $DOWNLOAD_DIR/docker-compose-$RELEASE.yml -p greenbone-community-edition \
     exec -u gvmd gvmd gvmd --user=admin --new-password=$password
 
 echo

--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -21,17 +21,32 @@ set -e
 DOWNLOAD_DIR=$HOME/greenbone-community-container
 
 installed() {
-    # $1 should be the command to look for
-    if ! [ -x "$(command -v $1)" ]; then
-        echo "$1 is not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
+    # $1 should be the command to look for. If $2 is set, we have arguments
+    local failed=0
+    if [ -z "$2" ]; then
+        if ! [ -x "$(command -v $1)" ]; then
+            failed=1
+        fi
+    else
+        local ret=0
+        $@ &> /dev/null || ret=$?
+        if [ "$ret" -ne 0 ]; then
+            failed=1
+        fi
+    fi
+
+    if [ $failed -ne 0 ]; then
+        echo "$@ is not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
         exit 1
     fi
+
 }
 
 RELEASE="22.4"
 
 installed curl
 installed docker
+installed docker compose
 
 echo "Using Greenbone Community Containers $RELEASE"
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update gsad to 22.5.2
 * Update GSA to 22.6.0
 * Update gvm-libs to 22.7.0
+* Replace docker-compose v1 with Docker Compose v2
 
 ## 23.7.0 – 23-07-25
 * Update gvmd to 22.6.0


### PR DESCRIPTION
## What
This PR updated the documentation to use the official Docker repo instead of the Debian / Ubuntu one to install the Docker packages.
It's mainly for docker-compose to use the latest release instead of the EOL Debian / Ubuntu package or the one from PyPi. Compose is now installed as a CLI plugin with version 2 instead of a standalone binary in version 1.

## Why
`The final Compose V1 release, version 1.29.2, was May 10, 2021. These packages haven't received any security updates since then. Use at your own risk.` (from https://docs.docker.com/compose/migrate/).
Both the Debian / Ubuntu package and the PyPi package contain Compose v1, which we shouldn't recommend using any more (Note: Compose v2 will be available for the upcoming Ubuntu 23.10 as `docker-compose-v2`).

I adapted the Docker install guide (https://docs.docker.com/engine/install/), but with minor adjustments, like using `apt` instead of `apt-get` and not installing `docker-buildx-plugin`, because we don't need it.

## References
Supersedes https://github.com/greenbone/docs/pull/368 (also installed Compose v2, but as a standalone binary)

## Checklist
I tested this updated instructions (up to the point where the containers were successfully started) on Ubuntu 22.04 and CentOS 8 using https://app.vagrantup.com/generic/boxes/ubuntu2204 and https://app.vagrantup.com/generic/boxes/centos8.