### PR TITLE
Update download.md

### DIFF
--- a/src/22.4/source-build/notus-scanner/download.md
+++ b/src/22.4/source-build/notus-scanner/download.md
@@ -2,7 +2,7 @@
 :caption: Downloading the notus-scanner sources
 
 curl -f -L https://github.com/greenbone/notus-scanner/archive/refs/tags/v$NOTUS_VERSION.tar.gz -o $SOURCE_DIR/notus-scanner-$NOTUS_VERSION.tar.gz
-curl -f -L https://github.com/greenbone/notus-scanner/releases/download/v$NOTUS_VERSION/notus-scanner-$NOTUS_VERSION.tar.gz.asc -o $SOURCE_DIR/notus-scanner-$NOTUS_VERSION.tar.gz.asc
+curl -f -L https://github.com/greenbone/notus-scanner/releases/download/v$NOTUS_VERSION/notus-scanner-v$NOTUS_VERSION.tar.gz.asc -o $SOURCE_DIR/notus-scanner-$NOTUS_VERSION.tar.gz.asc
 ```
 
 ```{code-block}


### PR DESCRIPTION
the notus-scanner download URL for /releases/download requires the prepended 'v' for NOTUS_VERSION for both the path and the filename. Existing version of this command only has the 'v' in the path causing a 404 error.

## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


