### PR TITLE
Change: Group Dependabot updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
   schedule:
     interval: "weekly"
     time: "04:00"
+  groups:
+    python-packages:
+      patterns:
+        - "*"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: direct
@@ -15,3 +19,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  groups:
+    github-actions:
+      patterns:
+        - "*"


### PR DESCRIPTION
## What

This groups multiple dependency updates into a single pull request when they are submitted by Dependabot.

## Why

The ability to process dependency updates through a single pull request reduces the workload for repository maintenance.

## References

See
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups for details on this functionality.
