### PR TITLE
Change: Update GSA to the 22.7.1 release

### DIFF
--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -100,7 +100,7 @@ The Greenbone Security Assistant (GSA) sources consist of two parts:
 ```{code-block}
 :caption: Setting the GSA version to use
 
-export GSA_VERSION=22.7.0
+export GSA_VERSION=22.7.1
 ```
 
 ```{include} /22.4/source-build/gsa/download.md

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ## Latest
 * Add workflow page for source builds
 * Add documentation for updating source builds
+* Update GSA to 22.7.1
 
 ## 23.9.0 - 23-09-23
 * Update pg-gvm to 22.6.1


### PR DESCRIPTION


## What

Update GSA to the 22.7.1 release

## Why

Use the newest GSA release in source build to include some bug fixes.