### PR TITLE
Change: Don't expose MQTT broker on all host interfaces

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -136,8 +136,6 @@ services:
   mqtt-broker:
     restart: on-failure
     image: greenbone/mqtt-broker
-    ports:
-      - 1883:1883
     networks:
       default:
         aliases:


### PR DESCRIPTION
## What

 Don't expose MQTT broker on all host interfaces

## Why

This was added mostly for testing purposes and is not required for running the community edition. Because the MQTT broker doesn't use authentication this could even be a security risk when using the docker container in some productive environment.

## References

Fixes #366

