### PR TITLE
Change: Don't listen on all docker host addresses for gsad

### DIFF
--- a/src/22.4/container/workflows.md
+++ b/src/22.4/container/workflows.md
@@ -198,7 +198,7 @@ Scan config Full and fast (daba56c8-73ec-11df-a475-002264764cea) has been create
 ## Accessing the Web Interface Remotely
 
 When using the docker compose file, the web server is configured to listen only
-on local address of the host (127.0.0.1). To allow remote access on all
+on the local address of the host (127.0.0.1). To allow remote access on all
 interfaces of the host, the compose file must be modified to configure the web
 server {command}`gsad` to listen on all network interfaces.
 

--- a/src/22.4/container/workflows.md
+++ b/src/22.4/container/workflows.md
@@ -195,6 +195,33 @@ caption: gvmd scan config loaded log message
 Scan config Full and fast (daba56c8-73ec-11df-a475-002264764cea) has been created by admin
 ```
 
+## Accessing the Web Interface Remotely
+
+When using the docker compose file, the web server is configured to listen only
+on local address of the host (127.0.0.1). To allow remote access on all
+interfaces of the host, the compose file must be modified to configure the web
+server {command}`gsad` to listen on all network interfaces.
+
+The following change of the docker compose file must be applied:
+
+```{code-block} diff
+---
+caption: Allowing access on all host interfaces
+---
+...
+  gsa:
+    image: greenbone/gsa:stable
+    restart: on-failure
+    ports:
+-      - 127.0.0.1:9392:80
++      - 9392:80
+    volumes:
+      - gvmd_socket_vol:/run/gvmd
+    depends_on:
+      - gvmd
+...
+```
+
 ## Starting from Scratch
 
 To start from scratch, the containers must be stopped. Afterwards, the

--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -89,7 +89,7 @@ services:
     image: greenbone/gsa:stable
     restart: on-failure
     ports:
-      - 9392:80
+      - 127.0.0.1:9392:80
     volumes:
       - gvmd_socket_vol:/run/gvmd
     depends_on:

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update GSA to 22.7.1
 * Don't expose MQTT broker port in docker compose setup by default
 * Add workflow for source builds on howto access GSA/gsad remotely
+* Only run gsad on 127.0.0.1 for the community containers setup
+* Add workflow for container setup on howto access GSA/gsad remotely
 
 ## 23.9.0 - 23-09-23
 * Update pg-gvm to 22.6.1


### PR DESCRIPTION


## What

Don't listen on all docker host addresses for gsad
## Why

For security reasons only expose gsad on the localhost address of the docker host when using the container setup.

## References

#398
