### PR TITLE
Fix log warning caused by tini init server in ospd-openvas container

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -98,7 +98,6 @@ services:
   ospd-openvas:
     image: greenbone/ospd-openvas:stable
     restart: on-failure
-    init: true
     hostname: ospd-openvas.local
     cap_add:
       - NET_ADMIN # for capturing packages in promiscuous mode

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Add workflow for source builds on howto access GSA/gsad remotely
 * Only run gsad on 127.0.0.1 for the community containers setup
 * Add workflow for container setup on howto access GSA/gsad remotely
+* Fix log warning from tini init server in the ospd-openvas container
 
 ## 23.9.0 - 23-09-23
 * Update pg-gvm to 22.6.1


### PR DESCRIPTION



## What

Fix log warning caused by tini init server in ospd-openvas container

## Why

Remove warning message from the docker compose log output to not confuse users. It worked as it should nevertheless.
