### PR TITLE
Fix: Adjust container workflow for manual feed sync

### DIFF
--- a/src/22.4/container/manual-feed-sync.md
+++ b/src/22.4/container/manual-feed-sync.md
@@ -8,14 +8,14 @@ Please be aware that the manually synced data will be overridden if the data
 containers are (re-)started.
 ```
 
-For the manual feed sync the [`greenbone-feed-sync`](https://github.com/greenbone/greenbone-feed-sync/)
+For the manual feed sync, the [`greenbone-feed-sync`](https://github.com/greenbone/greenbone-feed-sync/)
 script will be used. The `greenbone-feed-sync` script is also provided via a
 container image. Using the container image requires extending the docker compose
 file as follows:
 
 ```{code-block} yaml
 ---
-caption: Extend the docker compose file for performing a manual feed sync using
+caption: Extending the docker compose file for performing a manual feed sync using
     the greenbone-feed-sync script
 ---
 ...
@@ -54,7 +54,7 @@ docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-editio
 ```{code-block} shell
 ---
 caption: Downloading {term}`notus<notus-scanner>` {term}`VTs<VT>` processed by
-    the notus-scanner, this will take a while.
+    the Notus Scanner, this will take a while.
 ---
 docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
     run --rm greenbone-feed-sync greenbone-feed-sync --type notus

--- a/src/22.4/container/manual-feed-sync.md
+++ b/src/22.4/container/manual-feed-sync.md
@@ -1,10 +1,34 @@
 ## Performing a Manual Feed Sync
 
-It is possible to do a manual feed sync using {command}`rsync`.
+It is possible to do a manual feed sync using {command}`rsync` instead of
+pulling the current feed content via the newest container images.
 
 ```{warning}
 Please be aware that the manually synced data will be overridden if the data
 containers are (re-)started.
+```
+
+For the manual feed sync the [`greenbone-feed-sync`](https://github.com/greenbone/greenbone-feed-sync/)
+script will be used. The `greenbone-feed-sync` script is also provided via a
+container image. Using the container image requires extending the docker compose
+file as follows:
+
+```{code-block} yaml
+---
+caption: Extend the docker compose file for performing a manual feed sync using
+    the greenbone-feed-sync script
+---
+...
+  greenbone-feed-sync:
+    image: greenbone/greenbone-feed-sync
+    volumes:
+      - vt_data_vol:/var/lib/openvas/plugins
+      - notus_data_vol:/var/lib/notus
+      - gvmd_data_vol:/var/lib/gvm
+      - scap_data_vol:/var/lib/gvm/scap-data
+      - cert_data_vol:/var/lib/gvm/cert-data
+      - data_objects_vol:/var/lib/gvm/data-objects/gvmd
+...
 ```
 
 ### Syncing Vulnerability Tests
@@ -20,22 +44,31 @@ available for 22.4.
 
 ```{code-block} shell
 ---
-caption: Syncing {term}`VTs<VT>` processed by the scanner, this will take a while.
+caption: Downloading {term}`NASL<NASL>` {term}`VTs<VT>` processed by the
+    ospd-openvas scanner, this will take a while.
 ---
 docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    run --rm ospd-openvas greenbone-nvt-sync
+    run --rm greenbone-feed-sync greenbone-feed-sync --type nasl
 ```
 
+```{code-block} shell
+---
+caption: Downloading {term}`notus<notus-scanner>` {term}`VTs<VT>` processed by
+    the notus-scanner, this will take a while.
+---
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+    run --rm greenbone-feed-sync greenbone-feed-sync --type notus
+```
 ### Syncing SCAP, CERT and GVMD Data
 
 {term}`SCAP` data contains {term}`CPE` and {term}`CVE` information.
 
 ```{code-block} shell
 ---
-caption: Syncing SCAP data processed by gvmd, this will take a while
+caption: Downloading SCAP data processed by gvmd, this will take a while
 ---
 docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    run --rm gvmd greenbone-feed-sync --type SCAP
+    run --rm greenbone-feed-sync greenbone-feed-sync --type scap
 ```
 
 CERT data contains vulnerability information from the German [DFN-CERT](https://www.dfn-cert.de/)
@@ -43,19 +76,19 @@ and [CERT-Bund](https://cert-bund.de/) agencies.
 
 ```{code-block} shell
 ---
-caption: Syncing CERT data processed by gvmd
+caption: Downloading CERT data processed by gvmd
 ---
 docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    run --rm gvmd greenbone-feed-sync --type CERT
+    run --rm greenbone-feed-sync greenbone-feed-sync --type cert
 ```
 
-gvmd data (or also called data-objects) are scan configurations, compliance policies, port lists
-and report formats.
+gvmd data (or also called data-objects) are scan configurations, compliance
+policies, port lists and report formats.
 
 ```{code-block} shell
 ---
-caption: Syncing data objects processed by gvmd
+caption: Downloading data objects processed by gvmd
 ---
 docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    run --rm gvmd greenbone-feed-sync --type GVMD_DATA
+    run --rm gvmd greenbone-feed-sync --type gvmd-data
 ```

--- a/src/22.4/container/workflows.md
+++ b/src/22.4/container/workflows.md
@@ -44,7 +44,7 @@ done automatically when the daemons are running.
 The data of the {term}`Greenbone Community Feed` is provided via several
 container images. When these images are started, they copy the data into the used
 docker volumes automatically. Afterwards, the data is picked up from the
-volumes by the running daemons .
+volumes by the running daemons.
 
 To download the latest feed data container images run
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Only run gsad on 127.0.0.1 for the community containers setup
 * Add workflow for container setup on howto access GSA/gsad remotely
 * Fix log warning from tini init server in the ospd-openvas container
+* Fix manual feed sync workflow for the container setup
 
 ## 23.9.0 - 23-09-23
 * Update pg-gvm to 22.6.1


### PR DESCRIPTION


## What

Adjust container workflow for manual feed sync

## Why

After fixing the permissions in the feed data container images it's finally possible to run a manual feed sync again. Therefore fix and update the container workflow for doing a manual feed sync using the `greenbone-feed-sync` script.

## References
#367
