### PR TITLE
Change: Update gvm-libs, gvmd, gsad and GSA to latest releases

### DIFF
--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -26,7 +26,7 @@ The components should be build and installed in the listed order.
 ```{code-block}
 :caption: Setting the gvm-libs version to use
 
-export GVM_LIBS_VERSION=22.7.1
+export GVM_LIBS_VERSION=22.7.3
 ```
 
 ```{include} /22.4/source-build/gvm-libs/dependencies.md
@@ -48,7 +48,7 @@ Afterwards, gvm-libs can be build and installed.
 ```{code-block}
 :caption: Setting the gvmd version to use
 
-export GVMD_VERSION=22.9.0
+export GVMD_VERSION=23.0.0
 ```
 
 ```{include} /22.4/source-build/gvmd/dependencies.md
@@ -100,7 +100,7 @@ The Greenbone Security Assistant (GSA) sources consist of two parts:
 ```{code-block}
 :caption: Setting the GSA version to use
 
-export GSA_VERSION=22.7.1
+export GSA_VERSION=22.8.0
 ```
 
 ```{include} /22.4/source-build/gsa/download.md
@@ -117,7 +117,7 @@ export GSA_VERSION=22.7.1
 ```{code-block}
 :caption: Setting the GSAd version to use
 
-export GSAD_VERSION=22.6.0
+export GSAD_VERSION=22.7.0
 ```
 
 ```{include} /22.4/source-build/gsad/dependencies.md

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -8,13 +8,16 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ## Latest
 * Add workflow page for source builds
 * Add documentation for updating source builds
-* Update GSA to 22.7.1
 * Don't expose MQTT broker port in docker compose setup by default
 * Add workflow for source builds on howto access GSA/gsad remotely
 * Only run gsad on 127.0.0.1 for the community containers setup
 * Add workflow for container setup on howto access GSA/gsad remotely
 * Fix log warning from tini init server in the ospd-openvas container
 * Fix manual feed sync workflow for the container setup
+* Update gvm-libs to 22.7.3
+* Update gvmd to 23.0.0
+* Update gsad to 22.7.0
+* Update GSA to 22.8.0
 
 ## 23.9.0 - 23-09-23
 * Update pg-gvm to 22.6.1


### PR DESCRIPTION


## What

Update gvm-libs, gvmd, gsad and GSA to latest releases

## Why

Use latest releases for gvm-libs, gvmd, gsad and GSA for the source build guide.