### PR TITLE
Change: Quote passwords when creating an admin user

### DIFF
--- a/src/22.4/container/admin-user.md
+++ b/src/22.4/container/admin-user.md
@@ -13,5 +13,10 @@ generated password, the following command can be used:
 caption: Updating password of administrator user
 ---
 docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    exec -u gvmd gvmd gvmd --user=admin --new-password=<password>
+    exec -u gvmd gvmd gvmd --user=admin --new-password='<password>'
+```
+
+```{note}
+Please be aware if your password includes special characters like `$` it needs
+to be quoted in single quotes.
 ```

--- a/src/22.4/source-build/admin-user.md
+++ b/src/22.4/source-build/admin-user.md
@@ -20,7 +20,12 @@ password, the following command can be used:
 ```{code-block}
 :caption: Creating an administrator user with provided password
 
-/usr/local/sbin/gvmd --create-user=admin --password=<password>
+/usr/local/sbin/gvmd --create-user=admin --password='<password>'
+```
+
+```{note}
+Please be aware if your password includes special characters like `$` it needs
+to be quoted in single quotes.
 ```
 
 If the output doesn't show

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## Latest
 * Add instructions to enable SSL/TLS
+* Quote passwords when creating an admin user via `gvmd`
 
 ## 23.11.0
 * Add workflow page for source builds


### PR DESCRIPTION


## What

Quote passwords when creating an admin user

## Why

If the password isn't quoted via single quotes it will interpreted by the shell and therefore characters like `$` have special meanings.

## References

https://forum.greenbone.net/t/cannot-change-admin-password/16575