### PR TITLE
Change: Add hints for handling errors to generic troubleshooting page

### DIFF
--- a/src/22.4/source-build/troubleshooting.md
+++ b/src/22.4/source-build/troubleshooting.md
@@ -9,26 +9,6 @@ Community Edition via a Linux Distribution (for example Kali Linux), the
 commands may be slightly different and need to be adjusted.
 ```
 
-### Facing an issue with the Greenbone Community Edition
-
-If you have an issue with the Greenbone Community Edition because something
-doesn't work as expected and/or you are getting an error in the web UI it is
-necessary to check the log files to get some technical hints about the issue.
-
-If something doesn't work during the scan the {file}`/var/log/gvm/ospd-openvas.log`
-and {file}`/var/log/gvm/openvas.log` files should be checked for errors.
-
-Otherwise the {file}`/var/log/gvm/gvmd.log` file needs to be inspected.
-
-Afterwards using the collected error messages in the [search of our Community Forum](https://forum.greenbone.net/search)
-may bring up possible results to resolve the issue already.
-
-If no fitting results can be found feel free to create a new topic at our
-[Community Forum](https://forum.greenbone.net/). A post in the forum should
-always contain the installation method and the version of the Greenbone
-Community Edition (build from source via this guide, official community
-containers, Kali packages, ...) and the found error message.
-
 ### Failed to find port_list ‘33d0cd82-57c6-11e1-8ed1-406186ea4fc5‘
 
 This error can occur when tying to use the Task Wizard to create a quick scan

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -10,6 +10,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Add instructions to enable SSL/TLS
 * Quote passwords when creating an admin user via `gvmd`
 * Add a disclaimer that Greenbone isn't involved in packaging for Kali Linux
+* Move `Facing an issue with the Greenbone Community Edition` section from
+  source build troubleshooting to generic troubleshooting page
 
 ## 23.11.0
 * Add workflow page for source builds

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -8,6 +8,27 @@ Greenbone Community Edition.
 - For community container specific troubleshooting see [Troubleshooting the community containers](./22.4/container/troubleshooting.md).
 - For Kali Linux specific troubleshooting see [Troubleshooting a Kali Linux installation](./22.4/kali/troubleshooting.md).
 
+### Facing an issue with the Greenbone Community Edition
+
+If you have an issue with the Greenbone Community Edition because something
+doesn't work as expected and/or you are getting an error in the web UI it is
+necessary to check the log files to get some technical hints about the issue.
+
+If something doesn't work during the scan the {file}`/var/log/gvm/ospd-openvas.log`
+and {file}`/var/log/gvm/openvas.log` files should be checked for errors.
+
+Otherwise the {file}`/var/log/gvm/gvmd.log` file needs to be inspected.
+
+Afterwards using the collected error messages in the [search of our Community Forum](https://forum.greenbone.net/search)
+may bring up possible results to resolve the issue already.
+
+If no fitting results can be found feel free to create a new topic at our
+[Community Forum](https://forum.greenbone.net/). A post in the forum should
+always contain the installation method and the version of the Greenbone
+Community Edition (build from source via this guide, official community
+containers, Kali packages, ...) and the found error message.
+
+
 ## My scan does not show any results
 
 After a finished scan, your report does not contain any results or errors.


### PR DESCRIPTION


## What

Add hints for handling errors to generic troubleshooting page

The hints on the source build guide are valid for all variants of our software (maybe only partly for the containers but nevertheless).

## Why

Allow to point users to this description for many topics in the community forum.

## References

For example https://forum.greenbone.net/t/unable-to-install-openvas-in-virtualbox/16593

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


