### PR TITLE
Add: Add a section on how to access the logs of the community containers

### DIFF
--- a/src/22.4/container/troubleshooting.md
+++ b/src/22.4/container/troubleshooting.md
@@ -2,6 +2,64 @@
 
 This page contains hints for troubleshooting Greenbone Community Container specific issues.
 
+### Facing an issue with the Greenbone Community Containers
+
+If you have an issue with the Greenbone Community Containers because something
+doesn't work as expected and/or you are getting an error in the web UI it is
+necessary to check the log output to get some technical hints about the issue.
+
+To inspect the logs you can use the [`docker compose logs`](https://docs.docker.com/engine/reference/commandline/compose_logs/)
+command. For displaying the complete log output you can run
+
+```{code-block} shell
+---
+caption: Display all logs
+---
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+    logs
+```
+
+To follow the current log output to display log messages as they occur use the
+following command
+
+```{code-block} shell
+---
+caption: Follow current log output
+---
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+    logs -f
+```
+
+It's also possible to just display the logs of a specific container by using
+`docker compose logs <service>` where service is the [name of the container
+within the docker compose file](./index.md#description).
+
+```{code-block} shell
+---
+caption: Follow the log messages of the gvmd container only
+---
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+    logs -f gvmd
+```
+
+Additionally it is possible to bypass the `docker compose log` command and
+access the log files directly. For example run the following command to display
+the content of the OpenVAS scanner log file via {command}`cat`
+
+```{code-block} shell
+---
+caption: Print messages from /var/log/gvm/openvas.log
+---
+docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
+    exec ospd-openvas cat /var/log/gvm/openvas.log
+```
+
+Afterwards using the collected error messages in the [search of our Community Forum](https://forum.greenbone.net/search)
+may bring up possible results to resolve the issue already.
+
+If no fitting results can be found feel free to create a new topic the
+[Community Containers category in our Community Forum](https://forum.greenbone.net/c/community-containers/40).
+
 ### VTs are up-to-date but not visible on the web interface
 
 It may be possible, especially for the initial synchronization, that the scanner

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Add a disclaimer that Greenbone isn't involved in packaging for Kali Linux
 * Move `Facing an issue with the Greenbone Community Edition` section from
   source build troubleshooting to generic troubleshooting page
+* Add section about getting the log messages for the Community Containers
 * Update gvm-libs to 22.8.0
 * Update gvmd to 23.2.0
 * Update pg-gvm to 22.6.4


### PR DESCRIPTION


## What

Add a section on how to access the logs of the community containers

## Why

Not all people using our containers seem to be familiar with `docker` and `docker compose` and therefore might not know how to get access to the log messages. Therefore explain in detail how to get log messages from our software stack when
running the community containers.

## References

https://forum.greenbone.net/t/how-to-move-docker-based-installation-to-other-host/16716/3

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


