### PR TITLE
Change: Update --no-redirect description in container workflow

### DIFF
--- a/src/22.4/container/workflows.md
+++ b/src/22.4/container/workflows.md
@@ -409,7 +409,7 @@ mkdir $HOME/.ssl && mv serverkey.pem servercert.pem $HOME/.ssl
 Finally, the {term}`GSA` configuration in the `docker-compose.yml` file must be modified to enable SSL/TLS. The changes include:
 
 1. Setting the `GSAD_ARGS` environment variable to initialize SSL/TLS. In the example below, three arguments are set. A complete list of {term}`GSAD` arguments are in the gsad manpage (execute `gsad --help` from within the GSA container), and in the [GSAD documentation](https://github.com/greenbone/gsad/tree/main/doc) in its GitHub repository. The arguments used in this example are:
-    - `--no-redirect`: Allows HTTP and HTTPS connections to the web interface
+    - `--no-redirect`: Don't redirect HTTP to HTTPS and only allow HTTPS connections to the web interface
     - `--http-sts`: Enables HSTS (HTTP Strict Transport Security) for the GSAD web-server
     - `--gnutls-priorities`: Disables insecure versions of TLS (1.0 and 1.1)  
 2. Copying the private key and certificate files from the host system into the GSA container upon initialization.


### PR DESCRIPTION
## What
`gsad --help` says:

```
--no-redirect                           Don't redirect HTTP to HTTPS.
```

This is also matching what i know about this parameter, i the parameter isn't given and the `root` is used gsad will listen like this:

```
$ sudo /opt/gvm/sbin/gsad
$ sudo netstat -nplut | grep gsad
tcp6       0      0 :::443                  :::*                    LISTEN      42501/gsad          
tcp6       0      0 :::80                   :::*                    LISTEN      42502/gsad
sudo killall gsad
```

But if you're giving `--no-redirect` only `443` is listening:

```
$ sudo /opt/gvm/sbin/gsad --no-redirect
$ sudo netstat -nplut | grep gsad
tcp6       0      0 :::443                  :::*                    LISTEN      42603/gsad 
```

## Why
Improved description of the parameter.

## References
N/A