### PR TITLE
Change python project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For a manual build locally Python >= 3.9 and [poetry] is required.
 
 ## Install Poetry
 
+The project requires poetry >= 1.8.0.
+
 To install poetry it is recommended to use [pipx]. pipx can be installed with
 the following command on Debian based systems:
 
@@ -31,7 +33,7 @@ and up to date. To install for the first time or to update the project
 dependencies via [poetry] run:
 
 ```sh
-poetry install --no-root
+poetry install
 ```
 
 You should run this command once a week to install the latest dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "greenbone-docs"
 version = "1.0.0"
 description = "Documentation for the Greenbone Community Edition"
 authors = ["Greenbone Networks <info@greenbone.net>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "greenbone-docs"
 version = "1.0.0"
-description = "Documentation for the Community around the Greenbone Source Edition"
+description = "Documentation for the Greenbone Community Edition"
 authors = ["Greenbone Networks <info@greenbone.net>"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## What

Require poetry 1.8.0 to use non package mode 

## Why

In the non package mode poetry can be used to maintain projects not
intended for publishing a python package on pypi. This is exactly the
use case for our docs project. We are just using poetry for maintaining
and installing the dependencies.
