### PR TITLE
Add: Improve troubleshooting of failed of failed to find port list

### DIFF
--- a/src/22.4/source-build/feed-loading.md
+++ b/src/22.4/source-build/feed-loading.md
@@ -85,7 +85,7 @@ data is loaded. For port lists, these messages are similar to:
 ```{code-block} none
 :caption: gvmd port list loaded log message
 
- Port list All IANA assigned TCP (33d0cd82-57c6-11e1-8ed1-406186ea4fc5) has been created by admin
+Port list All IANA assigned TCP (33d0cd82-57c6-11e1-8ed1-406186ea4fc5) has been created by admin
 ```
 
 For report formats:

--- a/src/22.4/source-build/troubleshooting.md
+++ b/src/22.4/source-build/troubleshooting.md
@@ -24,8 +24,8 @@ caption: Checking if port list is already synced
 find /var/lib/gvm/data-objects/ -name "*33d0cd82-57c6-11e1-8ed1-406186ea4fc5*.xml"
 ```
 
-If the {command}`find` command does not return an XML file for your release, the
-data objects have not been synced from the {term}`feed` (yet).
+If the {command}`find` command does not return an XML file, the data objects
+have not been synced from the {term}`feed` (yet).
 
 ```{code-block} shell
 ---
@@ -42,6 +42,15 @@ the port lists from the disk.
 caption: Syncing data objects processed by gvmd
 ---
 sudo -u gvm gvmd --rebuild-gvmd-data=all
+```
+
+When {command}`gvmd` has loaded the port list successfully the {file}`/var/log/gvm/gvmd.log`
+file shows the following output
+
+```{code-block} none
+:caption: gvmd port list loaded log message
+
+Port list All IANA assigned TCP (33d0cd82-57c6-11e1-8ed1-406186ea4fc5) has been created by admin
 ```
 
 ### Failed to find scan configuration

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Move `Facing an issue with the Greenbone Community Edition` section from
   source build troubleshooting to generic troubleshooting page
 * Add section about getting the log messages for the Community Containers
+* Improved troubleshooting for *Failed to find port_list*
 * Update gvm-libs to 22.8.0
 * Update gvmd to 23.2.0
 * Update pg-gvm to 22.6.4


### PR DESCRIPTION

## What

Improve troubleshooting of failed of failed to find port list

## Why

Mention the log message when gvmd indicated it actually has loaded the port list from the feed.

## References

https://forum.greenbone.net/t/failed-to-find-port-list-33d0cd82-57c6-11e1-8ed1-406186ea4fc5/16925

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


