### PR TITLE
Change: Make the release version less visible

### DIFF
--- a/src/22.4/container/index.md
+++ b/src/22.4/container/index.md
@@ -1,4 +1,4 @@
-# Greenbone Community Containers 22.4
+# Greenbone Community Containers
 
 ```{include} /22.4/container/preamble.md
 ```

--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -1,4 +1,4 @@
-# Building 22.4 from Source
+# Building from Source
 
 ```{include} /22.4/source-build/introduction.md
 ```

--- a/src/index.md
+++ b/src/index.md
@@ -20,8 +20,7 @@ issues and incomplete functionality may appear.
 The sources of the Greenbone Community Edition are adopted by third parties, for
 example Linux distributions like Kali, Alpine, etc.
 
-This documentation covers the stable (22.4) version of the Greenbone Community
-Edition.
+This documentation covers the stable version of the Greenbone Community Edition.
 
 ```{image} _static/greenbone-banner.png
 ```


### PR DESCRIPTION
## What

Make the release version less visible

## Why

We only have a single maintained release which was known as 22.4. Since this release nearly all our software components switched to semver instead of calver and are released independently now. Thus showing 22.4 can be confusing when gvmd, openvas-scanner and other components are at 23.x.y. Also we are already in the year 22.4 which gives the impression our software may be already two years old without further releases.

