### PR TITLE
Fix compose command for downloading gvmd data manually

### DIFF
--- a/src/22.4/container/manual-feed-sync.md
+++ b/src/22.4/container/manual-feed-sync.md
@@ -90,5 +90,5 @@ policies, port lists and report formats.
 caption: Downloading data objects processed by gvmd
 ---
 docker compose -f $DOWNLOAD_DIR/docker-compose.yml -p greenbone-community-edition \
-    run --rm gvmd greenbone-feed-sync --type gvmd-data
+    run --rm greenbone-feed-sync greenbone-feed-sync --type gvmd-data
 ```

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -15,6 +15,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Add section about getting the log messages for the Community Containers
 * Extend history about current release changes and semver usage
 * Improved troubleshooting for *Failed to find port_list*
+* Fix command for downloading gvmd-data manual manually when using the
+  containers
 * Update gvm-libs to 22.8.0
 * Update gvmd to 23.2.0
 * Update pg-gvm to 22.6.4


### PR DESCRIPTION


## What

Fix compose command for downloading gvmd data manually

## Why

The greenbone-feed-sync application must be run within a greenbone-feed-sync container. Otherwise it wont be available.

## References

https://forum.greenbone.net/t/error-exec-greenbone-feed-sync-executable-file-not-found-in-path/17082/8

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


