### PR TITLE
OpenVasd Build Documation

### DIFF
--- a/src/22.4/source-build/openvasd/build.md
+++ b/src/22.4/source-build/openvasd/build.md
@@ -4,7 +4,7 @@
     .. code-block::
       :caption: Installing openvas-scanner
 
-      cd $SOURCE_DIR/openvas-scanner-$NOTUS_VERSION/rust/openvasd
+      cd $SOURCE_DIR/openvas-scanner-$OPENVAS_DAEMON/rust/openvasd
 
       cargo build --release
 
@@ -15,7 +15,7 @@
       :caption: Installing openvas-scanner
 
 
-      cd $SOURCE_DIR/openvas-scanner-$NOTUS_VERSION/rust/openvasd
+      cd $SOURCE_DIR/openvas-scanner-$OPENVAS_DAEMON/rust/openvasd
 
       cargo build --release
 


### PR DESCRIPTION
Fixed export variable for the path name for OpenVasd.

## What
Fixing OpenVasd Build documentation

## Why

It needs correct export variable to change to the correct directory


