### PR TITLE
OpenVas-Scanner Adding information on missing package

### DIFF
--- a/src/22.4/source-build/openvas-scanner/build.md
+++ b/src/22.4/source-build/openvas-scanner/build.md
@@ -14,6 +14,9 @@ cmake $SOURCE_DIR/openvas-scanner-$OPENVAS_SCANNER_VERSION \
 
 make -j$(nproc)
 ```
+```{warning}
+If missing libcurl error in Ubuntu install libcurl4-openssl-dev `sudo apt install -y libcurl4-openssl-dev`
+```
 
 ```{code-block}
 :caption: Installing openvas-scanner


### PR DESCRIPTION
When I went over the documentation, I had the issue of missing Libcurl when trying to build from cmake. According to the online documentation, Ubuntu doesn't have a direct libcurl-dev package, and using libcurl4-openssl-dev fixes the issue.
[additional post about Ubuntu 22.04 missing libcurl](https://youtrack.jetbrains.com/issue/KTOR-5894/Curl-Document-how-to-install-libcurl-on-Ubuntu-22.04)

## What

I'm adding a warning that if libcurl is missing, here's the package if needed. It is also possible to just add the package to the requirements if the repo owner deems it necessary.

## Why

It helps users when building, not having to research why libcurl is missing a package for CMake.




