### PR TITLE
Openvasd: fix incorrect install path when moving files to final destination

### DIFF
--- a/src/22.4/source-build/openvasd/build.md
+++ b/src/22.4/source-build/openvasd/build.md
@@ -6,7 +6,7 @@ cargo build --release
 cd $SOURCE_DIR/openvas-scanner-$OPENVAS_DAEMON/rust/scannerctl
 cargo build --release
 
-sudo cp -v ../target/release/openvasd $INSTALL_DIR/usr/local/bin/
-sudo cp -v ../target/release/scannerctl $INSTALL_DIR/usr/local/bin/
+sudo cp -v ../target/release/openvasd $INSTALL_DIR/openvasd/usr/local/bin/
+sudo cp -v ../target/release/scannerctl $INSTALL_DIR/openvasd/usr/local/bin/
 sudo cp -rv $INSTALL_DIR/openvasd/* /
 ```

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## Latest
+* Corrected the path for moving the openvasd built files
 * Add instructions for Kali Linux installation
 * Add instructions to enable SSL/TLS
 * Quote passwords when creating an admin user via `gvmd`


### PR DESCRIPTION
## What

Openvasd: fix incorrect install path when moving files to final destination

## References

https://forum.greenbone.net/t/missing-content-after-installation-according-to-files/17931/2

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [* ] [Changelog](src/changelog.md) entry


