### PR TITLE
Rollback MQTT removal - Add MQTT installation and config back into source code build guide

### DIFF
--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -221,6 +221,9 @@ export OPENVAS_DAEMON=23.0.1
 ```{include} /22.4/source-build/redis.md
 ```
 
+```{include} /22.4/source-build/mqtt-broker.md
+```
+
 ```{include} /22.4/source-build/directory-permissions.md
 ```
 

--- a/src/22.4/source-build/mqtt-broker.md
+++ b/src/22.4/source-build/mqtt-broker.md
@@ -1,0 +1,31 @@
+### Setting up the Mosquitto MQTT Broker
+
+The Mosquitto MQTT broker is used for communication between
+*ospd-openvas* and *openvas-scanner*.
+
+
+```{eval-rst}
+.. tabs::
+  .. tab:: Debian/Ubuntu
+   .. code-block::
+     :caption: Installing the Mosquitto broker
+
+     sudo apt install -y mosquitto
+
+  .. tab:: Fedora/CentOS
+   .. code-block::
+     :caption: Installing the Mosquitto broker
+
+     sudo dnf install -y mosquitto
+```
+
+After installing the Mosquitto broker package, the broker must be started
+and the server uri must be added to the *openvas-scanner* configuration.
+
+```{code-block}
+:caption: Starting the broker and adding the server uri to the openvas-scanner configuration
+
+sudo systemctl start mosquitto.service
+sudo systemctl enable mosquitto.service
+echo -e "mqtt_server_uri = localhost:1883\ntable_driven_lsc = yes" | sudo tee -a /etc/openvas/openvas.conf
+```

--- a/src/22.4/source-build/mqtt-broker.md
+++ b/src/22.4/source-build/mqtt-broker.md
@@ -3,6 +3,9 @@
 The Mosquitto MQTT broker is used for communication between
 *ospd-openvas* and *openvas-scanner*.
 
+```{note}
+In the future, planned changes to `ospd-openvas` will remove dependence on the Mosquitto MQTT broker, but for now it is still a requirement.
+```
 
 ```{eval-rst}
 .. tabs::

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## Latest
+* Re-added the installation and configuration of Mosquitto MQTT service to support `ospd-openvas`
 * Corrected the path for moving the openvasd built files
 * Add instructions for Kali Linux installation
 * Add instructions to enable SSL/TLS


### PR DESCRIPTION
## What

MQTT installation and configuration was removed from the source code build guide, but it is still required until further changes to `ospd-openvas`.
 
## References

https://forum.greenbone.net/t/openvas-executable-not-available/17944

## Checklist

- [x] [Changelog](src/changelog.md) entry


