### PR TITLE
Fix: Typo in environment variable and comment

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -135,7 +135,7 @@ services:
     restart: on-failure
     environment:
       # `service_notus` is set to disable everything but notus,
-      # if you want to utilize openvasd directly removed `OPENVAS_MOD`
+      # if you want to utilize openvasd directly removed `OPENVASD_MODE`
       OPENVASD_MODE: service_notus
       GNUPGHOME: /etc/openvas/gnupg
       LISTENING: 0.0.0.0:80

--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -136,7 +136,7 @@ services:
     environment:
       # `service_notus` is set to disable everything but notus,
       # if you want to utilize openvasd directly removed `OPENVAS_MOD`
-      OPENVASD_MOD: service_notus
+      OPENVASD_MODE: service_notus
       GNUPGHOME: /etc/openvas/gnupg
       LISTENING: 0.0.0.0:80
     volumes:
@@ -178,7 +178,7 @@ services:
         "--notus-feed-dir",
         "/var/lib/notus/advisories",
         "-m",
-        "666",
+        "666"
       ]
     volumes:
       - gpg_data_vol:/etc/openvas/gnupg


### PR DESCRIPTION
## What
This PR fixes a typo preventing the `openvasd` to start.

## Why
To allow `openvasd` to correctly start in `service_notus` mode.

## References
This has been introduced in https://github.com/greenbone/docs/pull/459.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] [Changelog](src/changelog.md) entry


