### PR TITLE
Fix: Remove not required `sudo` from documentation

### DIFF
--- a/src/22.4/source-build/openvas-scanner/build.md
+++ b/src/22.4/source-build/openvas-scanner/build.md
@@ -29,5 +29,5 @@ As of version 23.0 the `openvasd_server` configuration needs to be set to a runn
 
 ```{code-block}
 printf "table_driven_lsc = yes\n" | sudo tee /etc/openvas/openvas.conf
-sudo printf "openvasd_server = http://127.0.0.1:3000\n" | sudo tee -a /etc/openvas/openvas.conf
+printf "openvasd_server = http://127.0.0.1:3000\n" | sudo tee -a /etc/openvas/openvas.conf
 ```


### PR DESCRIPTION
no need to sudo before tee

## What

remove sudo command before tee

## Why

adding sudo everywhere is bad practice. This line isn't consistent with the rest of the documentation

## References

-

## Checklist

- [ N ] [Changelog](src/changelog.md) entry


