### PR TITLE
Change: Update versions of ospd-openvas and openvas-scanner

### DIFF
--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -162,7 +162,7 @@ export OPENVAS_SCANNER_VERSION=23.0.1
 ```{code-block}
 :caption: Setting the ospd and ospd-openvas versions to use
 
-export OSPD_OPENVAS_VERSION=22.6.2
+export OSPD_OPENVAS_VERSION=22.7.1
 ```
 
 ```{include} /22.4/source-build/ospd-openvas/dependencies.md

--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -142,7 +142,7 @@ export GSAD_VERSION=22.9.0
 ```{code-block}
 :caption: Setting the openvas-scanner version to use
 
-export OPENVAS_SCANNER_VERSION=23.0.1
+export OPENVAS_SCANNER_VERSION=23.8.0
 ```
 
 ```{include} /22.4/source-build/openvas-scanner/dependencies.md


### PR DESCRIPTION
## What

Update version of ospd-openvas to 22.7.1 and openvas-scanner to 23.8.0

## Why

- Closes #492 
- Could also replace / make #475 void

