### PR TITLE
Change openvasd version from 23.8.2 to 22.7.1

### DIFF
--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -182,7 +182,7 @@ export OSPD_OPENVAS_VERSION=22.7.1
 ```{code-block}
 :caption: Setting the openvas versions to use
 
-export OPENVAS_DAEMON=23.8.2
+export OPENVAS_DAEMON=22.7.1
 ```
 
 ```{include} /22.4/source-build/openvasd/dependencies.md


### PR DESCRIPTION
## What
Change openvasd version from 23.8.2 to 22.7.1 as it was reported that version 23.8.2 resulted in a 404 error.



