### PR TITLE
Remove: Drop mention of obsolete dependency on xml-twig-tools / perl-XML-Twig

### DIFF
--- a/src/22.4/source-build/gvmd/dependencies.md
+++ b/src/22.4/source-build/gvmd/dependencies.md
@@ -38,8 +38,7 @@
        python3 \
        smbclient \
        python3-lxml \
-       gnutls-bin \
-       xml-twig-tools
+       gnutls-bin
 
   .. tab:: Ubuntu
    .. code-block::
@@ -79,8 +78,7 @@
        python3 \
        smbclient \
        python3-lxml \
-       gnutls-bin \
-       xml-twig-tools
+       gnutls-bin
 
   .. tab:: Fedora
    .. code-block::
@@ -122,8 +120,7 @@
        socat \
        samba-client \
        python3-lxml \
-       gnutls-utils \
-       perl-XML-Twig
+       gnutls-utils
 
   .. tab:: CentOS
    .. code-block::
@@ -157,6 +154,5 @@
        socat \
        samba-client \
        python3-lxml \
-       gnutls-utils \
-       perl-XML-Twig
+       gnutls-utils
 ```

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -25,6 +25,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update GSA to 23.0.0
 * Update OpenVAS Scanner to 23.0.1
 * Drop notus-scanner in favor of the new OpenVAS Daemon (openvasd). This made the Mosquitto MQTT broker obsolete too.
+* Drop mention of obsolete dependency on xml-twig-tools / perl-XML-Twig
 
 ## 23.11.0
 * Add workflow page for source builds

--- a/test-build-and-install.sh
+++ b/test-build-and-install.sh
@@ -80,8 +80,7 @@ $APT_INSTALL \
   python3 \
   smbclient \
   python3-lxml \
-  gnutls-bin \
-  xml-twig-tools
+  gnutls-bin
 
 curl -f -L https://github.com/greenbone/gvmd/archive/refs/tags/v$GVMD_VERSION.tar.gz -o $SOURCE_DIR/gvmd-$GVMD_VERSION.tar.gz
 


### PR DESCRIPTION
## What
In greenbone/gvmd#2142 this dependency got dropped from `gvmd` but it was missed to remove / update the community docs itself.

## Why
Don't mention an unnecessary dependency

## References
- greenbone/gvmd#2142
- greenbone/gvmd#2321

## Checklist
- [x] [Changelog](src/changelog.md) entry