### PR TITLE
Quote variables for well defined behavior

### DIFF
--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -26,19 +26,19 @@ installed() {
     # $1 should be the command to look for. If $2 is set, we have arguments
     local failed=0
     if [ -z "$2" ]; then
-        if ! [ -x "$(command -v $1)" ]; then
+        if ! [ -x "$(command -v "$1")" ]; then
             failed=1
         fi
     else
         local ret=0
-        $@ &> /dev/null || ret=$?
+        "$@" &> /dev/null || ret=$?
         if [ "$ret" -ne 0 ]; then
             failed=1
         fi
     fi
 
     if [ $failed -ne 0 ]; then
-        echo "$@ is not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
+        echo "$* is not available. See https://greenbone.github.io/docs/latest/$RELEASE/container/#prerequisites."
         exit 1
     fi
 
@@ -48,24 +48,22 @@ installed curl
 installed docker
 installed docker compose
 
-echo "Using Greenbone Community Containers $RELEASE"
-
-mkdir -p $DOWNLOAD_DIR && cd $DOWNLOAD_DIR
+mkdir -p "$DOWNLOAD_DIR" && cd "$DOWNLOAD_DIR"
 
 echo "Downloading docker-compose file..."
 curl -f -O https://greenbone.github.io/docs/latest/_static/docker-compose.yml
 
 echo "Pulling Greenbone Community Containers"
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml pull
+docker compose -f "$DOWNLOAD_DIR"/docker-compose.yml pull
 echo
 
 echo "Starting Greenbone Community Containers"
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml up -d
+docker compose -f "$DOWNLOAD_DIR"/docker-compose.yml up -d
 echo
 
-read -s -p "Password for admin user: " password
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
-    exec -u gvmd gvmd gvmd --user=admin --new-password=$password
+read -r -s -p "Password for admin user: " password
+docker compose -f "$DOWNLOAD_DIR"/docker-compose.yml \
+    exec -u gvmd gvmd gvmd --user=admin --new-password="$password"
 
 echo
 echo "The feed data will be loaded now. This process may take several minutes up to hours."


### PR DESCRIPTION
By quoting variables we can improve stability of this script. $HOME and $password are both user supplied variables, that may contain spaces.

We need to quote them, or they may be expanded into extra arguments. This means this scripit will no longer break, if a space is supplied inside the password.


## What

In tests it was discovered that setup sometime fails. This turned out due to passwords that contain spaces, breaking the setup script.

This PR tries to fix this problem, and mitigates a couple of other potential issues.

Currently the problem still persists. I suspect that the same problem also happens inside the container entrypoint, and needs to be quoted there as well. Until then this PR will remain a **draft**.

## Why

Variables should be quoted if they may contain spaces (`$password`, `$DOWNLOAD_DIR`).

`read` treats backslashes differently, which can be annoying when entering a random password. with the `-r` flag we can disable this behavior.

`$@` will return an array of all arguments, which will then be translated into a string. When using `$*` we will get a sting which is safe to use, as its behavior is defined.

## References

[DEVOPS-1304](https://jira.greenbone.net/browse/DEVOPS-1304)
Test run failing in [test-community-containers](https://github.com/greenbone/greenbone-docker/actions/runs/11930003387/job/33249935851#step:8:4)

## Checklist
- [ ] [Changelog](src/changelog.md) entry


