### PR TITLE
Doc: add krb5-dev openvas dependency

### DIFF
--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -142,7 +142,7 @@ export GSAD_VERSION=22.11.0
 ```{code-block}
 :caption: Setting the openvas-scanner version to use
 
-export OPENVAS_SCANNER_VERSION=23.14.1
+export OPENVAS_SCANNER_VERSION=23.15.3
 ```
 
 ```{include} /22.4/source-build/openvas-scanner/dependencies.md
@@ -182,7 +182,7 @@ export OSPD_OPENVAS_VERSION=22.7.1
 ```{code-block}
 :caption: Setting the openvas versions to use
 
-export OPENVAS_DAEMON=23.14.1
+export OPENVAS_DAEMON=23.15.3
 ```
 
 ```{include} /22.4/source-build/openvasd/dependencies.md

--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -142,7 +142,7 @@ export GSAD_VERSION=22.11.0
 ```{code-block}
 :caption: Setting the openvas-scanner version to use
 
-export OPENVAS_SCANNER_VERSION=23.8.2
+export OPENVAS_SCANNER_VERSION=23.14.1
 ```
 
 ```{include} /22.4/source-build/openvas-scanner/dependencies.md
@@ -182,7 +182,7 @@ export OSPD_OPENVAS_VERSION=22.7.1
 ```{code-block}
 :caption: Setting the openvas versions to use
 
-export OPENVAS_DAEMON=23.8.2
+export OPENVAS_DAEMON=23.14.1
 ```
 
 ```{include} /22.4/source-build/openvasd/dependencies.md

--- a/src/22.4/source-build/openvas-scanner/dependencies.md
+++ b/src/22.4/source-build/openvas-scanner/dependencies.md
@@ -17,7 +17,7 @@
        libjson-glib-dev \
        libcurl4-gnutls-dev \
        libbsd-dev \
-       libkrb5-dev
+       krb5-multidev
 
    .. code-block::
      :caption: Debian optional dependencies for openvas-scanner

--- a/src/22.4/source-build/openvas-scanner/dependencies.md
+++ b/src/22.4/source-build/openvas-scanner/dependencies.md
@@ -16,7 +16,8 @@
        nmap \
        libjson-glib-dev \
        libcurl4-gnutls-dev \
-       libbsd-dev
+       libbsd-dev \
+       libkrb5-dev
 
    .. code-block::
      :caption: Debian optional dependencies for openvas-scanner
@@ -41,7 +42,8 @@
        nmap \
        json-glib-devel \
        libcurl-devel \
-       libbsd-devel
+       libbsd-devel \
+       krb5-devel
 
    .. code-block::
      :caption: Fedora optional dependencies for openvas-scanner
@@ -65,5 +67,6 @@
        nmap \
        json-glib-devel \
        libcurl-devel \
-       libbsd-devel
+       libbsd-devel \
+       krb5-devel
 ```

--- a/src/22.4/source-build/openvas-smb.md
+++ b/src/22.4/source-build/openvas-smb.md
@@ -32,21 +32,6 @@ export OPENVAS_SMB_VERSION=22.5.3
        heimdal-multidev \
        perl-base
 
-  .. tab:: Fedora
-   .. code-block::
-     :caption: Required dependencies for openvas-smb
-
-     sudo dnf install -y \
-       glib2-devel \
-       gnutls-devel \
-       popt-devel \
-       mingw64-gcc \
-       libunistring-devel \
-       heimdal-devel \
-       perl
-
-       sudo cp /usr/lib64/heimdal/lib/pkgconfig/heimdal-gssapi.pc /lib64/pkgconfig/heimdal-gssapi.pc
-       sudo cp /usr/lib64/heimdal/lib/pkgconfig/heimdal-krb5.pc /lib64/pkgconfig/heimdal-krb5.pc
 ```
 
 ```{code-block}

--- a/src/22.4/source-build/openvas-smb.md
+++ b/src/22.4/source-build/openvas-smb.md
@@ -29,7 +29,7 @@ export OPENVAS_SMB_VERSION=22.5.3
        libglib2.0-dev \
        libpopt-dev \
        libunistring-dev \
-       heimdal-dev \
+       heimdal-multidev \
        perl-base
 
   .. tab:: Fedora

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -8,6 +8,10 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ## Latest
 
 * Fix file path to compose file in setup and start script
+* Update openvas-smb dependecy from heimdal-dev to heimdal-multidev
+* Update openvas-scanner dependecy from libkrb5-dev to krb5-multidev
+* Update openvas-scanner and openvasd to 23.15.3
+* Remove fedora in openvas-smb.
 
 ## 25.1.0 - 2025-01-09
 


### PR DESCRIPTION
## What
Doc: add krb5-dev openvas dependency
Doc: remove fedora from openvas-smb as it does not build anymore.
Close greenbone/openvas-scanner#1803
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
missing dependency in openvas-scanner install documentation
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


