### PR TITLE
Update compose file to use 24.10 feed release

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -4,7 +4,7 @@ services:
   vulnerability-tests:
     image: registry.community.greenbone.net/community/vulnerability-tests
     environment:
-      STORAGE_PATH: /var/lib/openvas/22.04/vt-data/nasl
+      FEED_RELEASE: 24.10
     volumes:
       - vt_data_vol:/mnt
 
@@ -32,11 +32,15 @@ services:
 
   data-objects:
     image: registry.community.greenbone.net/community/data-objects
+    environment:
+      FEED_RELEASE: 24.10
     volumes:
       - data_objects_vol:/mnt
 
   report-formats:
     image: registry.community.greenbone.net/community/report-formats
+    environment:
+      FEED_RELEASE: 24.10
     volumes:
       - data_objects_vol:/mnt
     depends_on:
@@ -180,7 +184,7 @@ services:
         "--notus-feed-dir",
         "/var/lib/notus/advisories",
         "-m",
-        "666"
+        "666",
       ]
     volumes:
       - gpg_data_vol:/etc/openvas/gnupg

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -21,6 +21,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update GSA to 24.2.0 and the description
 * Drop python3-defusedxml from dependencies of gvm-tools
 * Simplify instructions for setting up sudo
+* Update docker compose file for using the 24.10 feed release
 
 ## 25.1.0 - 2025-01-09
 


### PR DESCRIPTION


## What

Update compose file to use 24.10 feed release

## Why

Use the correct feed for gvmd 25.0.0.

## References

https://jira.greenbone.net/browse/GEA-905

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


