### PR TITLE
Fix setting the FEED_RELEASE in compose file

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -4,7 +4,7 @@ services:
   vulnerability-tests:
     image: registry.community.greenbone.net/community/vulnerability-tests
     environment:
-      FEED_RELEASE: 24.10
+      FEED_RELEASE: "24.10"
     volumes:
       - vt_data_vol:/mnt
 
@@ -33,14 +33,14 @@ services:
   data-objects:
     image: registry.community.greenbone.net/community/data-objects
     environment:
-      FEED_RELEASE: 24.10
+      FEED_RELEASE: "24.10"
     volumes:
       - data_objects_vol:/mnt
 
   report-formats:
     image: registry.community.greenbone.net/community/report-formats
     environment:
-      FEED_RELEASE: 24.10
+      FEED_RELEASE: "24.10"
     volumes:
       - data_objects_vol:/mnt
     depends_on:


### PR DESCRIPTION

## What

Fix setting the FEED_RELEASE in compose file
## Why

Unquoted values in YAML (and also JSON) files are considered as numbers and therefore the trailing zero is cut from the feed release environment variable. To fix this the FEED_RELEASE value needs to be quoted.

## References

https://github.com/greenbone/docs/commit/f5e6adfff52be5b76b0b5c49b854e5caf7bc5d63#commitcomment-152409226
https://forum.greenbone.net/t/vulnerability-tests-service-fails-to-start-on-new-docker-install/20397
Closes https://github.com/greenbone/docs/issues/549


