### PR TITLE
Fix: Add libcjson to dependencies of gvm-libs

### DIFF
--- a/src/22.4/source-build/gvm-libs/dependencies.md
+++ b/src/22.4/source-build/gvm-libs/dependencies.md
@@ -5,18 +5,19 @@
      :caption: Required dependencies for gvm-libs
 
      sudo apt install -y \
-      libcurl4-gnutls-dev \
-      libgcrypt-dev \
-      libglib2.0-dev \
-      libgnutls28-dev \
-      libgpgme-dev \
-      libhiredis-dev \
-      libnet1-dev \
-      libpaho-mqtt-dev \
-      libpcap-dev \
-      libssh-dev \
-      libxml2-dev \
-      uuid-dev
+       libcjson-dev \
+       libcurl4-gnutls-dev \
+       libgcrypt-dev \
+       libglib2.0-dev \
+       libgnutls28-dev \
+       libgpgme-dev \
+       libhiredis-dev \
+       libnet1-dev \
+       libpaho-mqtt-dev \
+       libpcap-dev \
+       libssh-dev \
+       libxml2-dev \
+       uuid-dev
 
    .. code-block::
      :caption: Optional dependencies for gvm-libs

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -22,6 +22,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Drop python3-defusedxml from dependencies of gvm-tools
 * Simplify instructions for setting up sudo
 * Update docker compose file for using the 24.10 feed release
+* Add libcjson dependency for gvm-libs
 
 ## 25.1.0 - 2025-01-09
 


### PR DESCRIPTION


## What

Add libcjson to dependencies of gvm-libs

## Why

gvm-libs depends on libcjson for the openvasd interface too.

## References

https://github.com/greenbone/docs/issues/515#issuecomment-2654641799

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


