### PR TITLE
Remove: Drop `lcov` development dependency in gvmd install instructions

### DIFF
--- a/src/22.4/source-build/gvmd/dependencies.md
+++ b/src/22.4/source-build/gvmd/dependencies.md
@@ -5,7 +5,6 @@
      :caption: Required dependencies for gvmd
 
      sudo apt install -y \
-       lcov \
        libbsd-dev \
        libcjson-dev \
        libglib2.0-dev \

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update gvmd to 25.1.1
 * Update gsad to 24.2.2
 * Update GSA to 24.3.0
+* Drop `lcov` development dependency in gvmd install instructions
 
 ## 25.2.0 - 2025-02-18
 
@@ -160,7 +161,7 @@ argument from all docker compose commands.
 
 * Set `table_drive_lsc = yes` setting for openvas scanner to enable local
   security checks scanning via notus scanner
-* Remove docs for 21.04 because it is end-of-life and wont get any updates
+* Remove docs for 21.04 because it is end-of-life and won't get any updates
   anymore.
 * Extend FAQ for no results after finished scan
 * Update systemd service files to start the daemons in foreground to avoid


### PR DESCRIPTION
## What

From https://packages.debian.org/bookworm/lcov:

> Summarise Code coverage information from GCOV
>
> LCOV is an extension of GCOV, a GNU tool which provides information about what parts of a program are actually executed (i.e. "covered") while running a particular test case.

Installing this development dependency would install a huge amount of unnecessary dependencies (currently for my Debian testing system, might be even more on other "more clean" systems):

```
Summary:
  Upgrading: 0, Installing: 53, Removing: 0, Not Upgrading: 0
  Download size: 5.057 kB
  Space needed: 38,1 MB / 2.276 MB available
```

but none of the `gvmd` docs indicates that this is required / mandatory:

https://github.com/search?q=repo%3Agreenbone%2Fgvmd%20lcov&type=code

Could be even possible to drop the remaining parts on the `gvmd` repo as well if i understand greenbone/gvmd#1740 correctly.

## Why
Don't include unnecessary dependencies in the docs.

## References
None

## Checklist

- [x] [Changelog](src/changelog.md) entry