### PR TITLE
Patch 1

### DIFF
--- a/src/22.4/kali/installation.md
+++ b/src/22.4/kali/installation.md
@@ -88,4 +88,4 @@ Once the installation is complete you can log into the {term}`GSA` web interface
 
 Before starting the first scan, Greenbone needs to parse the vulnerability feeds and store them into the `gvmd` PostgreSQL database, otherwise, it will not be able to initialize or complete scans without errors. This process is initialized during the setup stage, but typically takes anywhere from a few minutes to several hours to complete, depending on your system resources.
 
-The feed status can be checked by going to the `Feed Status` page from the `Configuration` section in the top menu bar.
+The feed status can be checked by going to the `Feed Status` page from the `Administration` section in the top menu bar.

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update gsad to 24.2.2
 * Update GSA to 24.3.0
 * Drop `lcov` development dependency in gvmd install instructions
+* Fix - Docs copy (Feed Status moved to Administration) 
 
 ## 25.2.0 - 2025-02-18
 


### PR DESCRIPTION
Feed Status seems to have been moved to `Administration` section

## What

Minor copy fix, did not build docs to test

## Why

To clarify new position of the item for users in install guide

## References

N/A

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry
