### PR TITLE
Change: Put setting environment variables into an own section

### DIFF
--- a/src/22.4/source-build/prerequisites.md
+++ b/src/22.4/source-build/prerequisites.md
@@ -42,7 +42,20 @@ sudo usermod -aG gvm $USER
 su $USER
 ```
 
-### Choosing an Install Prefix
+### Setting Environment Variables
+
+For easier installation and not having to repeat the same directory paths over
+and over again the build from source guide uses [environment variables](https://en.wikipedia.org/wiki/Environment_variable).
+These environment variables are used later in the guide.
+
+```{attention}
+If you close your linux shell/terminal or start a new one, for example due to a
+system reboot while following this guide, you need to set the environment
+variables again. Environment variables are only valid in your current
+shell/terminal.
+```
+
+#### Choosing an Install Prefix
 
 Before building the software stack, a (root) directory must be chosen where
 the built software will finally be installed. For example, when building packages,
@@ -58,7 +71,7 @@ to be able to reference it later.
 export INSTALL_PREFIX=/usr/local
 ```
 
-### Setting the PATH
+#### Setting the PATH
 
 On Debian systems the locations {file}`/sbin`, {file}`/usr/sbin` and
 {file}`/usr/local/sbin` are not in the {envvar}`PATH` of normal users. To run
@@ -71,7 +84,7 @@ environment variable should be adjusted.
 export PATH=$PATH:$INSTALL_PREFIX/sbin
 ```
 
-### Creating a Source, Build and Install Directory
+#### Setting a Source, Build and Install Directory
 
 To separate the sources and the build artifacts, a source and a build directory
 must be created.

--- a/src/22.4/source-build/troubleshooting.md
+++ b/src/22.4/source-build/troubleshooting.md
@@ -100,7 +100,6 @@ If there are still no scan configs under {menuselection}`Configuration > Scan Co
 on the web interface after some hours and the logs of gvmd and ospd-openvas do not show
 errors, the `Feed Import Owner` may not have been set.
 
-
 ```{code-block} shell
 ---
 caption: Setting the `Feed Import Owner`
@@ -112,3 +111,13 @@ If all these steps do not resolve the issue, it is very likely a bigger problem,
 for example with the PostgreSQL database. Therefore, the
 {file}`/var/log/gvm/ospd-openvas.log` and {file}`/var/log/gvm/gvmd.log` files
 must be inspected for possible error and warning messages.
+
+### curl: (22) The requested URL returned error: 404
+
+While downloading some source file of the software components the URL can't be
+found and {command}`curl` returns a HTTP status code 404.
+
+Please ensure the version variable of the to be downloaded component and all
+[required environment variables](./index.md#setting-environment-variables) are
+set. If that doesn't work try to replace the variables in the curl command with
+the actual content.

--- a/src/22.4/source-build/workflows.md
+++ b/src/22.4/source-build/workflows.md
@@ -17,8 +17,7 @@ sudo systemctl stop gsad gvmd ospd-openvas openvasd
 ```
 
 Afterwards, you must verify that all [prerequisites](./index.md#prerequisites) are met.
-In particular, make sure that the [install prefix](./index.md#choosing-an-install-prefix), the
-[PATH](./index.md#setting-the-path) and the [required environment variables](./index.md#creating-a-source-build-and-install-directory)
+In particular, make sure that the [required environment variables](./index.md#setting-environment-variables)
 are set.
 
 For being able to update `ospd-openvas`, `greenbone-feed-sync` and `gvm-tools`

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -12,7 +12,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update gsad to 24.2.2
 * Update GSA to 24.3.0
 * Drop `lcov` development dependency in gvmd install instructions
-* Fix - Docs copy (Feed Status moved to Administration) 
+* Fix - Docs copy (Feed Status moved to Administration)
+* Update source build guide for a section explaining the environment variables
 
 ## 25.2.0 - 2025-02-18
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Drop `lcov` development dependency in gvmd install instructions
 * Fix - Docs copy (Feed Status moved to Administration)
 * Update source build guide for a section explaining the environment variables
+* Add section about getting a 404 to source guide troubleshooting
 
 ## 25.2.0 - 2025-02-18
 


### PR DESCRIPTION


## What


Put setting environment variables into an own section
## Why

Allow for better linking to a section setting all required env vars. Also explain the issues with environment variables being only valid in the current shell.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


