### PR TITLE
Improve hints for installing cargo on Debian and CentOS

### DIFF
--- a/src/22.4/source-build/openvasd/dependencies.md
+++ b/src/22.4/source-build/openvasd/dependencies.md
@@ -1,17 +1,18 @@
-```{note}
-For debian and centos systems you have to follow [rustup](https://rustup.rs) instructions because the default Rust version is too dated for `OpenVASD`
-```
 ```{eval-rst}
 .. tabs::
   .. tab:: Debian
+
+   .. attention::
+      For Debian systems you have to follow the `rustup <https://rustup.rs>`_ instructions because the default Rust version is too dated for `OpenVASD`
+
    .. code-block::
      :caption: Required dependencies for openvasd
 
-     # Follow instuctions of https://rustup.rs
+     # Follow instructions of https://rustup.rs to install cargo and afterwards run
 
      sudo apt install -y \
        pkg-config \
-       libssl-dev 
+       libssl-dev
 
   .. tab:: Ubuntu
    .. code-block::
@@ -20,7 +21,7 @@ For debian and centos systems you have to follow [rustup](https://rustup.rs) ins
      sudo apt install -y \
        cargo \
        pkg-config \
-       libssl-dev 
+       libssl-dev
 
   .. tab:: Fedora
    .. code-block::
@@ -32,10 +33,14 @@ For debian and centos systems you have to follow [rustup](https://rustup.rs) ins
        openssl-devel
 
   .. tab:: CentOS
+
+   .. attention::
+      For CentOS systems you have to follow the `rustup <https://rustup.rs>`_ instructions because the default Rust version is too dated for `OpenVASD`
+
    .. code-block::
      :caption: Required dependencies for openvasd
 
-     # Follow instuctions of https://rustup.rs
+     # Follow instructions of https://rustup.rs to install cargo and afterwards run
 
      sudo dnf install -y \
        pkg-config \

--- a/src/22.4/source-build/openvasd/description.md
+++ b/src/22.4/source-build/openvasd/description.md
@@ -1,11 +1,12 @@
 *OpenVASD* is used for detecting vulnerable products.
 
-Currently only the [notus](https://greenbone.github.io/scanner-api/#/notus/notus_run) is integrated into gvmd.
+Currently only the [notus](https://greenbone.github.io/scanner-api/#/notus/notus_run) service is integrated into gvmd.
 That means that `openvas` is using `openvasd` for static version checks if a scan with ssh credentials is started and packages got found.
 
 If you want to enable the full functionality you either need to adapt the `openvasd.service` file and remove the `--mode service_notus` flag and create a [configuration file](https://github.com/greenbone/openvas-scanner/blob/main/rust/examples/openvasd/config.example.toml) within `/etc/openvasd/openvasd.toml` or adapt the [arguments](https://github.com/greenbone/openvas-scanner/tree/main/rust/src/openvasd#options) within `openvasd.service` if you don't want to create a configuration file.
 
 For more information see:
-- https://greenbone.github.io/scanner-api/
-- https://github.com/greenbone/openvas-scanner/tree/main/rust/src/openvasd
-- https://github.com/greenbone/openvas-scanner/blob/main/rust/examples/openvasd/config.example.toml
+
+- <https://greenbone.github.io/scanner-api/>
+- <https://github.com/greenbone/openvas-scanner/tree/main/rust/src/openvasd>
+- <https://github.com/greenbone/openvas-scanner/blob/main/rust/examples/openvasd/config.example.toml>

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## Latest
 
+* Improve hints about following rustup.sh instructions on Debian and CentOS to
+  build openvasd
+
 ## 25.5.0 - 2025-05-30
 
 * Update gvm-libs to 22.22.0


### PR DESCRIPTION


## What

Improve hints for installing cargo on Debian and CentOS

## Why

On both distros the rust toolchain is too old for building openvasd. Therefore the users need to install it via rustup.sh.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


