### PR TITLE
Require Ubuntu 24.04 for source build

### DIFF
--- a/src/22.4/source-build/introduction.md
+++ b/src/22.4/source-build/introduction.md
@@ -19,7 +19,7 @@ production setups.
 Currently the docs support the following distributions
 
 - **Debian stable** [(bookworm)](https://www.debian.org/releases/stable)
-- **Ubuntu 22.04 LTS**
+- **Ubuntu 24.04 LTS**
 - **Fedora 38**
 - **CentOS 9 Stream**
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 
 * Improve hints about following rustup.sh instructions on Debian and CentOS to
   build openvasd
+* Require Ubuntu 24.04 for source build to fix building gvm-libs
 
 ## 25.5.0 - 2025-05-30
 


### PR DESCRIPTION


## What

Require Ubuntu 24.04 for source build

## Why
libcurl >= 7.83.0 is required for current gvm-libs and Ubuntu 22.04 comes with 7.81.0 only. Therefore gvm-libs can't be build on Ubuntu 22.04 anymore. Raise the requirement to Ubuntu 24.04 which ships with a sufficient libcurl version.


## References

Closes #565

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


