### PR TITLE
Ensure cargo is always up-to-date for openvasd

### DIFF
--- a/src/22.4/source-build/openvasd/dependencies.md
+++ b/src/22.4/source-build/openvasd/dependencies.md
@@ -8,29 +8,35 @@
    .. code-block::
      :caption: Required dependencies for openvasd
 
-     # Follow instructions of https://rustup.rs to install cargo and afterwards run
+     # Follow instructions of https://rustup.rs to install rustup and afterwards run
 
      sudo apt install -y \
        pkg-config \
        libssl-dev
+
+     rustup update stable
 
   .. tab:: Ubuntu
    .. code-block::
      :caption: Required dependencies for openvasd
 
      sudo apt install -y \
-       cargo \
+       rustup \
        pkg-config \
        libssl-dev
+
+     rustup update stable
 
   .. tab:: Fedora
    .. code-block::
      :caption: Required dependencies for openvasd
 
      sudo dnf install -y \
-       cargo \
+       rustup \
        pkg-config \
        openssl-devel
+
+     rustup update stable
 
   .. tab:: CentOS
 
@@ -40,9 +46,11 @@
    .. code-block::
      :caption: Required dependencies for openvasd
 
-     # Follow instructions of https://rustup.rs to install cargo and afterwards run
+     # Follow instructions of https://rustup.rs to install rustup and afterwards run
 
      sudo dnf install -y \
        pkg-config \
        openssl-devel
+
+     rustup update stable
 ```

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Improve hints about following rustup.sh instructions on Debian and CentOS to
   build openvasd
 * Require Ubuntu 24.04 for source build to fix building gvm-libs
+* Ensure cargo is up-to-date by running `rustup update stable` for openvasd
 
 ## 25.5.0 - 2025-05-30
 


### PR DESCRIPTION


## What

Ensure cargo is always up-to-date for openvasd

## Why

Distributions may ship with an too old cargo version for openvasd. Therefore update cargo to the latest stable version via rustup.

## References

https://forum.greenbone.net/t/openvasd-build-fails/21340/6

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


