### PR TITLE
docs: update redis-server to 8.2.2

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -52,7 +52,7 @@ services:
       - gpg_data_vol:/mnt
 
   redis-server:
-    image: registry.community.greenbone.net/community/redis-server
+    image: registry.community.greenbone.net/community/redis-server:8.2.2
     restart: on-failure
     volumes:
       - redis_socket_vol:/run/redis/


### PR DESCRIPTION
## What

Update redis-server image to version 8.2.2.

## Why

Ensures users run the patched Redis release.

## References

[DOS-483](https://jira.greenbone.net/browse/DOS-483)

## Checklist


- [ ] [Changelog](src/changelog.md) entry


