### PR TITLE
Update docker-compose-22.4.yml

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -95,7 +95,7 @@ services:
     image: registry.community.greenbone.net/community/gsa:stable
     restart: on-failure
     ports:
-      - 127.0.0.1:9392:80
+      - 9392:80
     volumes:
       - gvmd_socket_vol:/run/gvmd
     depends_on:


### PR DESCRIPTION
ports:
      - 9392:80

## What

<!--
  localhost (127.0.0.1 should not be added tot portforward config.
when changes the docker compose works en our students can deploy without futher knowledge
-->

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] [Changelog](src/changelog.md) entry


