### PR TITLE
Add POSTGRES_VERSION environment variable

### DIFF
--- a/src/_static/docker-compose-22.4.yml
+++ b/src/_static/docker-compose-22.4.yml
@@ -60,6 +60,8 @@ services:
   pg-gvm:
     image: registry.community.greenbone.net/community/pg-gvm:stable
     restart: on-failure
+    environment:
+      POSTGRES_VERSION: 15
     volumes:
       - psql_data_vol:/var/lib/postgresql
       - psql_socket_vol:/var/run/postgresql


### PR DESCRIPTION
Fixing this issue in the docs. https://forum.greenbone.net/t/pg-gvm-stable-no-longer-starting/21674

## What

<!--
  I was trying to setup a brand new docker stack and PG was failing to start correctly. Adding this line allowed the containers and services to startup. 
-->

## Why

Needed with move to postgres 15.

## References

https://github.com/greenbone/pg-gvm/issues/97

## Checklist

- [ ] [Changelog](src/changelog.md) entry


