### PR TITLE
Always use `compose.yaml` in the docs

### DIFF
--- a/src/22.4/container/admin-user.md
+++ b/src/22.4/container/admin-user.md
@@ -12,7 +12,7 @@ generated password, the following command can be used:
 ---
 caption: Updating password of administrator user
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
+docker compose -f $DOWNLOAD_DIR/compose.yaml \
     exec -u gvmd gvmd gvmd --user=admin --new-password='<password>'
 ```
 

--- a/src/22.4/container/manual-feed-sync.md
+++ b/src/22.4/container/manual-feed-sync.md
@@ -41,7 +41,7 @@ during a vulnerability scan.
 caption: Downloading {term}`NASL<NASL>` {term}`VTs<VT>` processed by the
     ospd-openvas scanner, this will take a while.
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
+docker compose -f $DOWNLOAD_DIR/compose.yaml \
     run --rm greenbone-feed-sync greenbone-feed-sync --type nasl
 ```
 
@@ -50,7 +50,7 @@ docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
 caption: Downloading `notus` {term}`VTs<VT>` processed for local security checks,
     this will take a while.
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
+docker compose -f $DOWNLOAD_DIR/compose.yaml \
     run --rm greenbone-feed-sync greenbone-feed-sync --type notus
 ```
 
@@ -62,7 +62,7 @@ docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
 ---
 caption: Downloading SCAP data processed by gvmd, this will take a while
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
+docker compose -f $DOWNLOAD_DIR/compose.yaml \
     run --rm greenbone-feed-sync greenbone-feed-sync --type scap
 ```
 
@@ -73,7 +73,7 @@ and [CERT-Bund](https://cert-bund.de/) agencies.
 ---
 caption: Downloading CERT data processed by gvmd
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
+docker compose -f $DOWNLOAD_DIR/compose.yaml \
     run --rm greenbone-feed-sync greenbone-feed-sync --type cert
 ```
 
@@ -84,6 +84,6 @@ policies, port lists and report formats.
 ---
 caption: Downloading data objects processed by gvmd
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
+docker compose -f $DOWNLOAD_DIR/compose.yaml \
     run --rm greenbone-feed-sync greenbone-feed-sync --type gvmd-data
 ```

--- a/src/22.4/container/starting.md
+++ b/src/22.4/container/starting.md
@@ -7,14 +7,14 @@ and the containers can be started in the background.
 ---
 caption: Downloading the Greenbone Community Containers
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml pull
+docker compose -f $DOWNLOAD_DIR/compose.yaml pull
 ```
 
 ```{code-block} shell
 ---
 caption: Starting the Greenbone Community Containers
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml up -d
+docker compose -f $DOWNLOAD_DIR/compose.yaml up -d
 ```
 
 To get a continuous stream of the log output of all services, run the following
@@ -24,7 +24,7 @@ command:
 ---
 caption: Show log messages of all services from the running containers
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml logs -f
+docker compose -f $DOWNLOAD_DIR/compose.yaml logs -f
 ```
 
 The log stream can be stopped by pressing {kbd}`Ctrl-C`.

--- a/src/22.4/container/troubleshooting.md
+++ b/src/22.4/container/troubleshooting.md
@@ -15,7 +15,7 @@ command. For displaying the complete log output you can run
 ---
 caption: Display all logs
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml logs
+docker compose -f $DOWNLOAD_DIR/compose.yaml logs
 ```
 
 To follow the current log output to display log messages as they occur use the
@@ -25,7 +25,7 @@ following command
 ---
 caption: Follow current log output
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml logs -f
+docker compose -f $DOWNLOAD_DIR/compose.yaml logs -f
 ```
 
 It's also possible to just display the logs of a specific container by using
@@ -36,7 +36,7 @@ within the docker compose file](./index.md#description).
 ---
 caption: Follow the log messages of the gvmd container only
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml logs -f gvmd
+docker compose -f $DOWNLOAD_DIR/compose.yaml logs -f gvmd
 ```
 
 Additionally it is possible to bypass the `docker compose log` command and
@@ -47,7 +47,7 @@ the content of the OpenVAS scanner log file via {command}`cat`
 ---
 caption: Print messages from /var/log/gvm/openvas.log
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
+docker compose -f $DOWNLOAD_DIR/compose.yaml \
     exec ospd-openvas cat /var/log/gvm/openvas.log
 ```
 
@@ -67,7 +67,7 @@ scanner.
 ---
 caption: Restart the scanner to ensure that new {term}`VTs<VT>` are loaded
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml restart ospd-openvas
+docker compose -f $DOWNLOAD_DIR/compose.yaml restart ospd-openvas
 ```
 
 ### Port list, scan configurations, report formats are up-to-date but not visible on the web interface
@@ -78,7 +78,7 @@ If port lists, scan configurations, or report formats are missing on the web int
 ---
 caption: Forcing reload of report formats, scan configs and port lists
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml \
+docker compose -f $DOWNLOAD_DIR/compose.yaml \
     exec -u gvmd gvmd gvmd --rebuild-gvmd-data=all
 ```
 
@@ -105,7 +105,7 @@ restart the corresponding container with:
 ---
 caption: Restarting the ospd-openvas scanner
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml restart ospd-openvas
+docker compose -f $DOWNLOAD_DIR/compose.yaml restart ospd-openvas
 ```
 
 If you still get errors, you need to take a look at the `ospd-openvas` logs.
@@ -114,7 +114,7 @@ If you still get errors, you need to take a look at the `ospd-openvas` logs.
 ---
 caption: Showing log message of the ospd-openvas scanner
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml log -f ospd-openvas
+docker compose -f $DOWNLOAD_DIR/compose.yaml log -f ospd-openvas
 ```
 
 ### Cannot log in to the web interface: *Greenbone Vulnerability Manager service is not responding*
@@ -138,7 +138,7 @@ had some issues accessing the PostgreSQL database.
 ---
 caption: Restarting {term}`gvmd`
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml restart gvmd
+docker compose -f $DOWNLOAD_DIR/compose.yaml restart gvmd
 ```
 
 ### Redis server keeps restarting `rm: cannot remove ‘/run/redis/redis.sock’: Permission denied`
@@ -153,8 +153,8 @@ The volume can be removed safely because it gets recreated on the next startup.
 ---
 caption: Recreating the Redis server socket volume
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml  \
+docker compose -f $DOWNLOAD_DIR/compose.yaml  \
     rm -s -f redis-server ospd-openvas
 docker volume rm greenbone-community-edition_redis_socket_vol
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml up -d
+docker compose -f $DOWNLOAD_DIR/compose.yaml up -d
 ```

--- a/src/22.4/container/workflows.md
+++ b/src/22.4/container/workflows.md
@@ -3,8 +3,8 @@
 ## Updating the Greenbone Community Containers
 
 ```{important}
-Please always ensure to use the latest version of the
-[docker-compose.yml](#docker-compose-file) file when following these steps. The
+Please always ensure to use the latest version of the docker
+[compose.yaml](#docker-compose-file) file when following these steps. The
 file might got updates and important changes since your last download.
 ```
 
@@ -16,14 +16,14 @@ be done with:
 ---
 caption: Downloading the Greenbone Community Containers
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml pull
+docker compose -f $DOWNLOAD_DIR/compose.yaml pull
 ```
 
 ```{code-block} shell
 ---
 caption: Starting the Greenbone Community Containers
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml up -d
+docker compose -f $DOWNLOAD_DIR/compose.yaml up -d
 ```
 
 ## Performing a Feed Synchronization
@@ -58,7 +58,7 @@ To download the latest feed data container images run
 ---
 caption: Downloading the Greenbone Community Edition feed data containers
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml pull notus-data vulnerability-tests scap-data dfn-cert-data cert-bund-data report-formats data-objects
+docker compose -f $DOWNLOAD_DIR/compose.yaml pull notus-data vulnerability-tests scap-data dfn-cert-data cert-bund-data report-formats data-objects
 ```
 
 To copy the data from the images to the volumes run
@@ -67,7 +67,7 @@ To copy the data from the images to the volumes run
 ---
 caption: Starting the Greenbone Community feed data containers
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml up -d notus-data vulnerability-tests scap-data dfn-cert-data cert-bund-data report-formats data-objects
+docker compose -f $DOWNLOAD_DIR/compose.yaml up -d notus-data vulnerability-tests scap-data dfn-cert-data cert-bund-data report-formats data-objects
 ```
 
 ### Loading the Feed Changes
@@ -262,7 +262,7 @@ by running:
 ---
 caption: Remove containers and volumes (all data)
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml down -v
+docker compose -f $DOWNLOAD_DIR/compose.yaml down -v
 ```
 
 ## Gaining a Terminal for a Container
@@ -277,7 +277,7 @@ To access a container with a bash shell as a root user, you can run:
 ---
 caption: Gain a Terminal for a Container
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml exec <container-name> /bin/bash
+docker compose -f $DOWNLOAD_DIR/compose.yaml exec <container-name> /bin/bash
 ```
 
 Afterwards, you can execute standard bash commands within the running container.
@@ -292,7 +292,7 @@ can be started with:
 ---
 caption: Start container for gvm-tools CLI access
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml run --rm gvm-tools
+docker compose -f $DOWNLOAD_DIR/compose.yaml run --rm gvm-tools
 ```
 
 Afterwards, a bash shell is provided and `gvm-cli`, `gvm-pyshell` or `gvm-script`
@@ -352,7 +352,7 @@ In the next step, the docker compose file must be changed as follows:
 After restarting the containers with
 
 ```bash
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml up -d
+docker compose -f $DOWNLOAD_DIR/compose.yaml up -d
 ```
 
 the Unix socket should be available at `/tmp/gvm/gvmd/gvmd.sock`. For example,
@@ -447,7 +447,7 @@ such as the user's home directory or the `tmp` directory.
 mkdir $HOME/.ssl && mv server.key server.cert.pem $HOME/.ssl
 ```
 
-Finally, the nginx configuration in the `docker-compose.yml` file must be
+Finally, the nginx configuration in the `compose.yaml` file must be
 modified to use the new certificate files.
 
 Sample `nginx` service settings to use own TLS certificate files:
@@ -472,12 +472,12 @@ Sample `nginx` service settings to use own TLS certificate files:
         condition: service_started
 ```
 
-After modifying the `docker-compose.yml` file, restart the containers to enable
+After modifying the `compose.yaml` file, restart the containers to enable
 the changes.
 
 ```{code-block} shell
 ---
 caption: Restart the Greenbone Community Containers
 ---
-docker compose -f $DOWNLOAD_DIR/docker-compose.yml up -d
+docker compose -f $DOWNLOAD_DIR/compose.yaml up -d
 ```

--- a/src/_static/setup-and-start-greenbone-community-edition.sh
+++ b/src/_static/setup-and-start-greenbone-community-edition.sh
@@ -50,19 +50,19 @@ installed docker compose
 
 mkdir -p "$DOWNLOAD_DIR" && cd "$DOWNLOAD_DIR"
 
-echo "Downloading docker-compose file..."
-curl -f -O https://greenbone.github.io/docs/latest/_static/docker-compose.yml
+echo "Downloading docker compose file..."
+curl -f -O https://greenbone.github.io/docs/latest/_static/compose.yaml
 
 echo "Pulling Greenbone Community Containers"
-docker compose -f "$DOWNLOAD_DIR"/docker-compose.yml pull
+docker compose -f "$DOWNLOAD_DIR"/compose.yaml pull
 echo
 
 echo "Starting Greenbone Community Containers"
-docker compose -f "$DOWNLOAD_DIR"/docker-compose.yml up -d
+docker compose -f "$DOWNLOAD_DIR"/compose.yaml up -d
 echo
 
 read -r -s -p "Password for admin user: " password
-docker compose -f "$DOWNLOAD_DIR"/docker-compose.yml \
+docker compose -f "$DOWNLOAD_DIR"/compose.yaml \
     exec -u gvmd gvmd gvmd --user=admin --new-password="$password"
 
 echo

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Provide a single compose file and remove the versioned compose file. The
   compose setup follows a rolling release model.
 * Rename `docker-compose.yml` to `compose.yaml` as the later one is the
-  preferred canonical name nowadays.
+  [preferred canonical name nowadays](https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file).
 * Update the compose architecture:
   * Use nginx to serve the GSA frontend.
   * Run gsad in API-only mode.
@@ -21,6 +21,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update gvm-libs to 22.31.1
 * Update gvmd to 26.10.0
 * Use [`restart_policy`](https://docs.docker.com/reference/compose-file/deploy/#restart_policy) for container services
+* Use `compose.yaml` instead of `docker-compose.yml` everywhere in the docs
 
 ## 26.2.0 - 2026-02-24
 


### PR DESCRIPTION


## What
Always use `compose.yaml` in the docs

## Why

`docker-compose.yml` is still downloadable due to a symlink but `compose.yaml` is the preferred name of the file nowadays. See https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


