### PR TITLE
Fix dependabot updates for uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: "weekly"
       time: "04:00"
-    groups:
-      python-packages:
-        patterns:
-          - "*"
     commit-message:
       prefix: "Deps"
     open-pull-requests-limit: 10
-    allow:
-      - dependency-type: direct
-      - dependency-type: indirect
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION


## What
Fix dependabot updates for uv

## Why

For dependabot updates using uv the package-ecosystem needs to use uv instead of pip. Otherwise the uv.lock file didn't get updates. Also don't group the updates to get isolated PRs. If a single dependency update fails other updates can still be applied.

