### PR TITLE
Use env variables to configure gsad settings in container setup

### DIFF
--- a/src/_static/compose.yaml
+++ b/src/_static/compose.yaml
@@ -128,7 +128,7 @@ services:
       MOUNT_PATH: "/mnt/web"
       KEEP_ALIVE: 1
     healthcheck:
-      test: ["CMD-SHELL", "test -e /run/gsa/copying.done"]
+      test: [ "CMD-SHELL", "test -e /run/gsa/copying.done" ]
       start_period: 5s
     volumes:
       - gsa_data_vol:/mnt/web
@@ -139,7 +139,9 @@ services:
       restart_policy:
         condition: any
     environment:
-      GSAD_ARGS: "--listen=0.0.0.0 --http-only --api-only -f"
+      GSAD_HTTP_ONLY: "true"
+      GSAD_API_ONLY: "true"
+      GSAD_FOREGROUND: "true"
     volumes:
       - gvmd_socket_vol:/run/gvmd
     depends_on:

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -22,6 +22,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 * Update gvmd to 26.10.0
 * Use [`restart_policy`](https://docs.docker.com/reference/compose-file/deploy/#restart_policy) for container services
 * Use `compose.yaml` instead of `docker-compose.yml` everywhere in the docs
+* Use environment variables for the settings of gsad
 
 ## 26.2.0 - 2026-02-24
 


### PR DESCRIPTION


## What

Use env variables to configure gsad settings in container setup

## Why
Environment variables are easier to change, override or to adapt then having the change the command line arguments.


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


