### PR TITLE
Update source build guide to use newest releases of GEA stack

### DIFF
--- a/src/22.4/source-build/index.md
+++ b/src/22.4/source-build/index.md
@@ -26,7 +26,7 @@ The components should be build and installed in the listed order.
 ```{code-block}
 :caption: Setting the gvm-libs version to use
 
-export GVM_LIBS_VERSION=22.31.1
+export GVM_LIBS_VERSION=23.9.3
 ```
 
 ```{include} /22.4/source-build/gvm-libs/dependencies.md
@@ -48,7 +48,7 @@ Afterwards, gvm-libs can be build and installed.
 ```{code-block}
 :caption: Setting the gvmd version to use
 
-export GVMD_VERSION=26.10.0
+export GVMD_VERSION=26.37.0
 ```
 
 ```{include} /22.4/source-build/gvmd/dependencies.md
@@ -100,7 +100,7 @@ The Greenbone Security Assistant (GSA) sources consist of two parts:
 ```{code-block}
 :caption: Setting the GSA version to use
 
-export GSA_VERSION=25.0.0
+export GSA_VERSION=28.3.0
 ```
 
 ```{include} /22.4/source-build/gsa/download.md
@@ -117,7 +117,7 @@ export GSA_VERSION=25.0.0
 ```{code-block}
 :caption: Setting the GSAd version to use
 
-export GSAD_VERSION=24.3.0
+export GSAD_VERSION=27.2.0
 ```
 
 ```{include} /22.4/source-build/gsad/dependencies.md
@@ -162,7 +162,7 @@ export OPENVAS_SCANNER_VERSION=23.20.1
 ```{code-block}
 :caption: Setting the ospd and ospd-openvas versions to use
 
-export OSPD_OPENVAS_VERSION=22.9.0
+export OSPD_OPENVAS_VERSION=22.10.5
 ```
 
 ```{include} /22.4/source-build/ospd-openvas/dependencies.md

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -18,14 +18,19 @@ and this project adheres to [Calendar Versioning](https://calver.org).
   * Use https in the default setup.
   * Port 9392 now redirects to 443.
 * Upgrade PostgreSQL to v16 for Ubuntu
-* Update gvm-libs to 22.31.1
-* Update gvmd to 26.10.0
 * Use [`restart_policy`](https://docs.docker.com/reference/compose-file/deploy/#restart_policy) for container services
 * Use `compose.yaml` instead of `docker-compose.yml` everywhere in the docs
 * Use environment variables for the settings of gsad
 * Refresh the GSA dashboard image
 * Revise the hardware specifications view
-* Rewrite the containre pre-requisites and -amble files
+* Rewrite the container pre-requisites and -amble files
+* Update component versions for source build
+  * Update gvm-libs to 23.9.3
+  * Update gvmd to 26.37.0
+  * Update gsad to 27.2.0
+  * Update gsa to 28.3.0
+  * Update pg-gvm to 22.6.18
+  * Update ospd-openvas to 22.10.5
 
 ## 26.2.0 - 2026-02-24
 


### PR DESCRIPTION


## What

Update source build guide to use newest releases of GEA stack

## Why

Beside that only update ospd-openvas scanner to latest release. Not sure if the other scanner components will build without issues. For the GEA stack I am confident it still builds on all supported platforms.
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] [Changelog](src/changelog.md) entry


